### PR TITLE
Target net462 for gRPC WinHttpHandler support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="Google.Protobuf" Version="3.23.4" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.55.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.56.2" />
+    <PackageVersion Include="Google.Protobuf" Version="3.24.2" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.56.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.57.0" />
     <PackageVersion Include="System.Text.Json" Version="7.0.3" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
 

--- a/Milvus.Client/Diagnostics/CompilerAttributes.cs
+++ b/Milvus.Client/Diagnostics/CompilerAttributes.cs
@@ -6,7 +6,7 @@
 
 namespace System.Runtime.CompilerServices;
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET462
 
 using ComponentModel;
 

--- a/Milvus.Client/Milvus.Client.csproj
+++ b/Milvus.Client/Milvus.Client.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <!-- We target net462 directly since the net462 version of Grpc.Net.Client automatically uses WinHttpHandler -->
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
     <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AnalysisMode>All</AnalysisMode>
@@ -43,7 +44,7 @@
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 

--- a/Milvus.Client/MilvusException.cs
+++ b/Milvus.Client/MilvusException.cs
@@ -1,8 +1,15 @@
-﻿namespace Milvus.Client;
+﻿#if NET462
+using System.Runtime.Serialization;
+#endif
+
+namespace Milvus.Client;
 
 /// <summary>
 /// Exception thrown for errors related to the Milvus client.
 /// </summary>
+#if NET462
+[Serializable]
+#endif
 public sealed class MilvusException : Exception
 {
     /// <summary>
@@ -33,4 +40,11 @@ public sealed class MilvusException : Exception
     {
         ErrorCode = errorCode;
     }
+
+#if NET462
+    private MilvusException(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(nameof(ErrorCode), ErrorCode);
+    }
+#endif
 }


### PR DESCRIPTION
This PR simplifies usage for .NET Framework users, where WinHttpHandler needs to be used. [This PR](https://github.com/grpc/grpc-dotnet/pull/2220) was recently merged, which makes the net462 version of Grpc.Net.Client automatically use WinHttpHandler; having Milvus.Client target net462 takes advantage of that as well.

/cc @stephentoub 