### PR TITLE
Change Dimension type from long to int

### DIFF
--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -76,7 +76,7 @@ public sealed class FieldSchema
     /// <param name="name">The field name.</param>
     /// <param name="dimension">The dimension of the vector. Must be greater than zero.</param>
     /// <param name="description">An optional description for the field.</param>
-    public static FieldSchema CreateFloatVector(string name, long dimension, string description = "")
+    public static FieldSchema CreateFloatVector(string name, int dimension, string description = "")
         => new(name, MilvusDataType.FloatVector, description: description) { Dimension = dimension };
 
     /// <summary>
@@ -85,7 +85,7 @@ public sealed class FieldSchema
     /// <param name="name">The field name.</param>
     /// <param name="dimension">The dimension of the vector. Must be greater than zero.</param>
     /// <param name="description">An optional description for the field.</param>
-    public static FieldSchema CreateBinaryVector(string name, long dimension, string description = "")
+    public static FieldSchema CreateBinaryVector(string name, int dimension, string description = "")
         => new(name, MilvusDataType.BinaryVector, description: description) { Dimension = dimension };
 
     /// <summary>
@@ -191,7 +191,7 @@ public sealed class FieldSchema
     /// The dimension of the vector. Mandatory for <see cref="MilvusDataType.FloatVector" />
     /// and <see cref="MilvusDataType.BinaryVector" /> fields, and must be greater than zero.
     /// </summary>
-    public long? Dimension { get; set; }
+    public int? Dimension { get; set; }
 
     /// <summary>
     /// The state of the field.

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -46,7 +46,7 @@ public partial class MilvusCollection
                         break;
 
                     case Constants.VectorDim:
-                        milvusField.Dimension = long.Parse(parameter.Value, CultureInfo.InvariantCulture);
+                        milvusField.Dimension = int.Parse(parameter.Value, CultureInfo.InvariantCulture);
                         break;
                 }
             }


### PR DESCRIPTION
The Milvus documentation defines the dimensions as an int between 1 and 32768, we had it typed as a long.