### PR TITLE
Properly handle empty Search results

### DIFF
--- a/Milvus.Client/MilvusCollection.Entity.cs
+++ b/Milvus.Client/MilvusCollection.Entity.cs
@@ -227,7 +227,7 @@ public partial class MilvusCollection
         {
             CollectionName = response.CollectionName,
             FieldsData = response.Results.FieldsData.Select(FieldData.FromGrpcFieldData).ToList(),
-            Ids = MilvusIds.FromGrpc(response.Results.Ids),
+            Ids = response.Results.Ids is null ? default : MilvusIds.FromGrpc(response.Results.Ids),
             NumQueries = response.Results.NumQueries,
             Scores = response.Results.Scores,
             Limit = response.Results.TopK,


### PR DESCRIPTION
When a Search returns zero results, Milvus returns null as the search result's IDs, rather than an empty list; this PR makes the client properly handle that.

Note also that the field data is empty in this case. Both of the above may make it trickier for consumers to deal with empty results in various ways.