### PR TITLE
Remove constructor overload ambiguity

### DIFF
--- a/Milvus.Client.Tests/TestEnvironment.cs
+++ b/Milvus.Client.Tests/TestEnvironment.cs
@@ -31,10 +31,10 @@ public static class TestEnvironment
     public static string? Database { get; private set; }
 
     public static MilvusClient CreateClient()
-        => new MilvusClient(Host, Port, Username, Password, Database);
+        => new MilvusClient(Host, Username, Password, Port, ssl: false, Database);
 
     public static MilvusClient CreateClientForDatabase(string database)
-        => new MilvusClient(Host, Port, Username, Password, database);
+        => new MilvusClient(Host, Username, Password, Port, ssl: false, database);
 
     public static MilvusClient Client { get; }
 }


### PR DESCRIPTION
The constructor overloads previously created an amguity as the overloads accepting user/pass and those accepting apiKey  were ambiguous because of optional parameters. This replaces the optional parameters with more overloads to reduce the ambiguity.

To summarize:
* There are 3 ways to pass in the endpoint:
  * Providing a hostname as a string, and optionally a port (defaults to 19530) and whether to use SSL (defaults to false). This is the simplest way.
  * Providing a Uri. This allows specifying HTTPs, port inside the URL, etc.
  * Providing an externally-constructed GrpcChannel (advanced scenarios).
* In addition, there are three authentication options:
  * No authentication whatsoever. Milvus by default has authentication turned off, so this is the easy default/getting started option.
  * Username and password
  * API key (for Zilliz cloud). Under the hood the API key is just passed via the same Authorization header as username/password (as if it's a username without a password), but it seems best to keep the constructor overloads here distinct both for clarity to users and in case something changes in the future.
* Multiplying the above endpoint and authentication possibilities yields 9 public constructor overloads in total, which seems OK.

/cc @stephentoub, note that this relates to this Semantic Kernel discussion: https://github.com/microsoft/semantic-kernel/pull/2694/files#r1314021272. Once this is merged here, we can replicate the 9 above constructors to MilvusMemoryStore, plus keep the additional advanced one that accepts a MilvusClient directly. Does this seem reasonable or a bit too much?