### PR TITLE
Rename SearchParameters.Parameters to ExtraParameters

### DIFF
--- a/Milvus.Client/MilvusCollection.Entity.cs
+++ b/Milvus.Client/MilvusCollection.Entity.cs
@@ -214,7 +214,7 @@ public partial class MilvusCollection
                 new Grpc.KeyValuePair
                 {
                     Key = Constants.Params,
-                    Value = parameters is null ? "{}" : Combine(parameters.Parameters)
+                    Value = parameters is null ? "{}" : Combine(parameters.ExtraParameters)
                 }
             });
 

--- a/Milvus.Client/SearchParameters.cs
+++ b/Milvus.Client/SearchParameters.cs
@@ -65,7 +65,7 @@ public class SearchParameters
     /// <remarks>
     /// See <see href="https://milvus.io/docs/index.md" /> for more information.
     /// </remarks>
-    public IDictionary<string, string> Parameters { get; } = new Dictionary<string, string>();
+    public IDictionary<string, string> ExtraParameters { get; } = new Dictionary<string, string>();
 
     /// <summary>
     /// Whether to ignore growing segments during similarity searches. Defaults to <c>false</c>, indicating that


### PR DESCRIPTION
To both align the "ExtraParameters" name with CreateIndexAsync (as these parameters are index-related), and to avoid having Parameters within a SearchParameters type.