### PR TITLE
Basic changes needed to get tests passing on Milvus 2.3

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - "2.3"
   pull_request:
 
 jobs:
@@ -14,7 +15,7 @@ jobs:
       matrix:
         # TODO: Test against latest previews too. This currently doesn't work because preview releases don't publish
         # a milvus-standalone-docker-compose.yml
-        milvus_version: [v2.2.11]
+        milvus_version: [v2.3.0]
 
     steps:
       - name: Checkout

--- a/Milvus.Client.Tests/IndexTests.cs
+++ b/Milvus.Client.Tests/IndexTests.cs
@@ -17,7 +17,7 @@ public class IndexTests : IAsyncLifetime
     {
         await Collection.CreateIndexAsync(
             "float_vector", IndexType.Flat, SimilarityMetricType.L2, indexName: "float_vector_idx");
-        await Collection.WaitForIndexBuildAsync("float_vector");
+        await Collection.WaitForIndexBuildAsync("float_vector", "float_vector_idx");
     }
 
     [Fact]
@@ -46,10 +46,6 @@ public class IndexTests : IAsyncLifetime
     [InlineData(IndexType.IvfSq8, """{ "nlist": "8" }""")]
     [InlineData(IndexType.IvfPq, """{ "nlist": "8", "m": "4" }""")]
     [InlineData(IndexType.Hnsw, """{ "efConstruction": "8", "M": "4" }""")]
-    [InlineData(IndexType.Annoy, """{ "n_trees": "10" }""")]
-    [InlineData(IndexType.RhnswFlat, """{ "efConstruction": "8", "M": "4" }""")]
-    [InlineData(IndexType.RhnswPq, """{ "efConstruction": "8", "M": "4", "PQM": "4" }""")]
-    [InlineData(IndexType.RhnswSq, """{ "efConstruction": "8", "M": "4" }""")]
     [InlineData(IndexType.AutoIndex, """{ }""")]
     public async Task Index_types_float(IndexType indexType, string extraParamsString)
     {
@@ -89,10 +85,7 @@ public class IndexTests : IAsyncLifetime
 
     [Theory]
     [InlineData(SimilarityMetricType.Jaccard)]
-    [InlineData(SimilarityMetricType.Tanimoto)]
     [InlineData(SimilarityMetricType.Hamming)]
-    [InlineData(SimilarityMetricType.Superstructure)]
-    [InlineData(SimilarityMetricType.Substructure)]
     public async Task Similarity_metric_types_binary(SimilarityMetricType similarityMetricType)
     {
         await Collection.DropAsync();
@@ -109,6 +102,7 @@ public class IndexTests : IAsyncLifetime
         await Collection.WaitForIndexBuildAsync("binary_vector");
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     [Fact]
     public async Task GetState()
     {
@@ -121,17 +115,19 @@ public class IndexTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetBuildProgress()
+    public async Task GetBuildProgress_with_name()
     {
         await Assert.ThrowsAsync<MilvusException>(() =>
-            Collection.GetIndexBuildProgressAsync("float_vector"));
+            Collection.GetIndexBuildProgressAsync("float_vector", indexName: "float_vector_idx"));
 
-        await Collection.CreateIndexAsync("float_vector", IndexType.Flat, SimilarityMetricType.L2);
-        await Collection.WaitForIndexBuildAsync("float_vector");
+        await Collection.CreateIndexAsync(
+            "float_vector", IndexType.Flat, SimilarityMetricType.L2, indexName: "float_vector_idx");
+        await Collection.WaitForIndexBuildAsync("float_vector", "float_vector_idx");
 
-        var progress = await Collection.GetIndexBuildProgressAsync("float_vector");
+        var progress = await Collection.GetIndexBuildProgressAsync("float_vector", "float_vector_idx");
         Assert.Equal(progress.TotalRows, progress.IndexedRows);
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     [Fact]
     public async Task Describe()
@@ -170,7 +166,9 @@ public class IndexTests : IAsyncLifetime
 
         await Collection.DropIndexAsync("float_vector", "float_vector_idx");
 
-        Assert.Equal(IndexState.None, await Collection.GetIndexStateAsync("float_vector"));
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(
+            () => Collection.DescribeIndexAsync("float_vector"));
+        Assert.Equal(MilvusErrorCode.IndexNotExist, exception.ErrorCode);
     }
 
     public async Task InitializeAsync()

--- a/Milvus.Client/Milvus.Client.csproj
+++ b/Milvus.Client/Milvus.Client.csproj
@@ -31,6 +31,7 @@
     <Protobuf Include="Protos\proto\common.proto" GrpcServices="Client" Access="internal" />
     <Protobuf Include="Protos\proto\schema.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
     <Protobuf Include="Protos\proto\milvus.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
+    <Protobuf Include="Protos\proto\feder.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Milvus.Client/MilvusCollection.Index.cs
+++ b/Milvus.Client/MilvusCollection.Index.cs
@@ -157,10 +157,27 @@ public partial class MilvusCollection
         {
             foreach (IndexDescription index in response.IndexDescriptions)
             {
+                IndexState state = index.State switch
+                {
+                    Grpc.IndexState.None => IndexState.None,
+                    Grpc.IndexState.Unissued => IndexState.Unissued,
+                    Grpc.IndexState.InProgress => IndexState.InProgress,
+                    Grpc.IndexState.Finished => IndexState.Finished,
+                    Grpc.IndexState.Failed => IndexState.Failed,
+                    Grpc.IndexState.Retry => IndexState.Retry,
+
+                    _ => throw new InvalidOperationException($"Unknown {nameof(Grpc.IndexState)}: {index.State}")
+                };
+
                 indexes.Add(new MilvusIndexInfo(
                     index.FieldName,
                     index.IndexName,
                     index.IndexID,
+                    state,
+                    index.IndexedRows,
+                    index.TotalRows,
+                    index.PendingIndexRows,
+                    index.IndexStateFailReason,
                     index.Params.ToDictionary(static p => p.Key, static p => p.Value)));
             }
         }
@@ -175,6 +192,7 @@ public partial class MilvusCollection
     /// <param name="cancellationToken">
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
     /// </param>
+    [Obsolete("Use DescribeIndex instead")]
     public async Task<IndexState> GetIndexStateAsync(string fieldName, CancellationToken cancellationToken = default)
     {
         Verify.NotNullOrWhiteSpace(fieldName);
@@ -207,6 +225,7 @@ public partial class MilvusCollection
     /// <param name="cancellationToken">
     /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
     /// </param>
+    [Obsolete("Use DescribeIndex instead")]
     public async Task<IndexBuildProgress> GetIndexBuildProgressAsync(
         string fieldName,
         string? indexName = null,
@@ -254,9 +273,23 @@ public partial class MilvusCollection
         await Utils.Poll(
             async () =>
             {
-                IndexBuildProgress progress = await GetIndexBuildProgressAsync(fieldName, indexName, cancellationToken)
-                    .ConfigureAwait(false);
-                return (progress.IsComplete, progress);
+                IList<MilvusIndexInfo> indexInfos =
+                    await DescribeIndexAsync(fieldName, indexName, cancellationToken).ConfigureAwait(false);
+
+                MilvusIndexInfo indexInfo = indexInfos.FirstOrDefault(i => i.FieldName == fieldName) ?? indexInfos[0];
+
+                var progress = new IndexBuildProgress(indexInfo.IndexedRows, indexInfo.TotalRows);
+
+                return indexInfo.State switch
+                {
+                    IndexState.Finished => (true, progress),
+                    IndexState.InProgress => (false, progress),
+
+                    IndexState.Failed
+                        => throw new MilvusException("Index creation failed: " + indexInfo.IndexStateFailReason),
+
+                    _ => throw new MilvusException("Index isn't building, state is " + indexInfo.State)
+                };
             },
             indexName is null
                 ? $"Timeout when waiting for index on collection '{Name}' to build"

--- a/Milvus.Client/MilvusErrorCode.cs
+++ b/Milvus.Client/MilvusErrorCode.cs
@@ -68,7 +68,6 @@ public enum MilvusErrorCode
     /// Coord is switching from standby mode to active mode
     /// </summary>
     NotReadyCoordActivating = Grpc.ErrorCode.NotReadyCoordActivating,
-    NotFoundTsafer = Grpc.ErrorCode.NotFoundTsafer,
 
     /// <summary>
     /// Service availability.

--- a/Milvus.Client/MilvusIndexInfo.cs
+++ b/Milvus.Client/MilvusIndexInfo.cs
@@ -9,11 +9,21 @@ public sealed class MilvusIndexInfo
         string fieldName,
         string indexName,
         long indexId,
+        IndexState state,
+        long indexedRows,
+        long totalRows,
+        long pendingIndexRows,
+        string? indexStateFailReason,
         IReadOnlyDictionary<string, string> @params)
     {
         FieldName = fieldName;
         IndexName = indexName;
         IndexId = indexId;
+        State = state;
+        IndexedRows = indexedRows;
+        TotalRows = totalRows;
+        PendingIndexRows = pendingIndexRows;
+        IndexStateFailReason = indexStateFailReason;
         Params = @params;
     }
 
@@ -31,6 +41,31 @@ public sealed class MilvusIndexInfo
     /// Index id.
     /// </summary>
     public long IndexId { get; }
+
+    /// <summary>
+    /// The state of the index.
+    /// </summary>
+    public IndexState State { get; }
+
+    /// <summary>
+    /// The number of rows indexed by this index;
+    /// </summary>
+    public long IndexedRows { get; }
+
+    /// <summary>
+    /// The total rows in the collection.
+    /// </summary>
+    public long TotalRows { get; }
+
+    /// <summary>
+    /// The number of pending rows in the index.
+    /// </summary>
+    public long PendingIndexRows { get; }
+
+    /// <summary>
+    /// If creation of the index failed, contains the reason for the failure.
+    /// </summary>
+    public string? IndexStateFailReason { get; }
 
     /// <summary>
     /// Contains index_type, metric_type, params.

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>2.2.2</Version>
+    <Version>2.3.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Note that this doesn't add any of the new 2.3 features - it just syncs to the new Protos and does the minimum changes to make all tests pass against Milvus 2.3.