### PR TITLE
Fix GetVersion test case failed for Milvus 2.2.0-latest

### DIFF
--- a/Milvus.Client.Tests/MiscTests.cs
+++ b/Milvus.Client.Tests/MiscTests.cs
@@ -37,7 +37,11 @@ public class MiscTests
 
     [Fact]
     public async Task GetVersion()
-        => Assert.Contains(".", await Client.GetVersionAsync());
+    {
+        string version =  await Client.GetVersionAsync();
+
+        Assert.NotEmpty(version);
+    }
 
     [Fact]
     public async Task Dispose()


### PR DESCRIPTION
As for Milvus 2.2.0-latest, the version name is 3f425f0e. 
- There is no "." in the middle therefore the test case is failed. 
- A simple not empty check should be fine