### PR TITLE
Array fields support

### DIFF
--- a/Milvus.Client.Tests/FieldTests.cs
+++ b/Milvus.Client.Tests/FieldTests.cs
@@ -67,4 +67,141 @@ public class FieldTests
         Assert.Equal(2, field.RowCount);
         Assert.Equal(2, field.Data.Count);
     }
+
+    [Fact]
+    public void CreateInt8ArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new sbyte[][]
+            {
+                [1, 2],
+                [3, 4],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Int8, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    [Fact]
+    public void CreateInt16ArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new short[][]
+            {
+                [1, 2],
+                [3, 4],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Int16, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    [Fact]
+    public void CreateInt32ArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new int[][]
+            {
+                [1, 2],
+                [3, 4],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Int32, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    [Fact]
+    public void CreateInt64ArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new long[][]
+            {
+                [1, 2],
+                [3, 4],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Int64, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    [Fact]
+    public void CreateBoolArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new bool[][]
+            {
+                [true, false],
+                [false, false],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Bool, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    [Fact]
+    public void CreateFloatArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new float[][]
+            {
+                [1, 2],
+                [3, 4],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Float, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    [Fact]
+    public void CreateDoubleArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new double[][]
+            {
+                [1, 2],
+                [3, 4],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.Double, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
+
+    //TODO: differentiate VarChar and String somehow
+    [Fact]
+    public void CreateVarCharArrayTest()
+    {
+        var field = FieldData.CreateArray(
+            "vector",
+            new string[][]
+            {
+                ["3d4d387208e04a9abe77be65e2b7c7b3", "a5502ddb557047968a70ff69720d2dd2"],
+                ["4c246789a91f4b15aa3b26799df61457", "00a23e95823b4f14854ceed5f7059953"],
+            });
+
+        Assert.Equal(MilvusDataType.Array, field.DataType);
+        Assert.Equal(MilvusDataType.VarChar, field.ElementType);
+        Assert.Equal(2, field.RowCount);
+        Assert.Equal(2, field.Data.Count);
+    }
 }

--- a/Milvus.Client.sln.DotSettings
+++ b/Milvus.Client.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_MULTILINE_CASE_SECTION/@EntryValue">1</s:Int64>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jaccard/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Milvus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pymilvus/@EntryIndexedValue">True</s:Boolean>

--- a/Milvus.Client.sln.DotSettings
+++ b/Milvus.Client.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pymilvus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=quantizes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=quantizing/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sbytes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tanimoto/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=topk/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=upserted/@EntryIndexedValue">True</s:Boolean>

--- a/Milvus.Client/ArrayFieldData.cs
+++ b/Milvus.Client/ArrayFieldData.cs
@@ -1,0 +1,187 @@
+﻿namespace Milvus.Client;
+
+/// <summary>
+/// Binary Field
+/// </summary>
+public sealed class ArrayFieldData<TElementData> : FieldData<IReadOnlyList<TElementData>>
+{
+    /// <summary>
+    /// Construct an array field
+    /// </summary>
+    /// <param name="fieldName"></param>
+    /// <param name="data"></param>
+    /// <param name="isDynamic"></param>
+    public ArrayFieldData(string fieldName, IEnumerable<IEnumerable<TElementData>> data, bool isDynamic)
+        : base(fieldName, data.Select(x => x.ToArray()).ToArray(), MilvusDataType.Array, isDynamic)
+    {
+        ElementType = EnsureDataType<TElementData>();
+    }
+
+    /// <summary>
+    /// Array element type
+    /// </summary>
+    public MilvusDataType ElementType { get; }
+
+    /// <inheritdoc />
+    internal override Grpc.FieldData ToGrpcFieldData()
+    {
+        Check();
+
+        Grpc.FieldData fieldData = new()
+        {
+            Type = Grpc.DataType.Array,
+            IsDynamic = IsDynamic
+        };
+
+        if (FieldName is not null)
+        {
+            fieldData.FieldName = FieldName;
+        }
+
+        var arrayArray = new ArrayArray
+        {
+            ElementType = (DataType) ElementType,
+        };
+
+        fieldData.Scalars = new ScalarField
+        {
+            ArrayData = arrayArray
+        };
+
+        foreach (var array in Data)
+        {
+            switch (ElementType)
+            {
+                case MilvusDataType.Bool:
+                    Grpc.BoolArray boolData = new();
+                    boolData.Data.AddRange(array as IEnumerable<bool>);
+                    arrayArray.Data.Add(new ScalarField {BoolData = boolData});
+                    break;
+
+                case MilvusDataType.Int8:
+                    Grpc.IntArray int8Data = new();
+                    var sbytes = array as IEnumerable<sbyte> ?? Enumerable.Empty<sbyte>();
+                    int8Data.Data.AddRange(sbytes.Select(x => (int) x));
+                    arrayArray.Data.Add(new ScalarField {IntData = int8Data});
+                    break;
+
+                case MilvusDataType.Int16:
+                    Grpc.IntArray int16Data = new();
+                    var shorts = array as IEnumerable<short> ?? Enumerable.Empty<short>();
+                    int16Data.Data.AddRange(shorts.Select(x=>(int)x));
+                    arrayArray.Data.Add(new ScalarField {IntData = int16Data});
+                    break;
+
+                case MilvusDataType.Int32:
+                    Grpc.IntArray int32Data = new();
+                    int32Data.Data.AddRange(array as IEnumerable<int>);
+                    arrayArray.Data.Add(new ScalarField {IntData = int32Data});
+                    break;
+
+                case MilvusDataType.Int64:
+                    Grpc.LongArray int64Data = new();
+                    int64Data.Data.AddRange(array as IEnumerable<long>);
+                    arrayArray.Data.Add(new ScalarField {LongData = int64Data});
+                    break;
+
+                case MilvusDataType.Float:
+                    Grpc.FloatArray floatData = new();
+                    floatData.Data.AddRange(array as IEnumerable<float>);
+                    arrayArray.Data.Add(new ScalarField {FloatData = floatData});
+                    break;
+
+                case MilvusDataType.Double:
+                    Grpc.DoubleArray doubleData = new();
+                    doubleData.Data.AddRange(array as IEnumerable<double>);
+                    arrayArray.Data.Add(new ScalarField {DoubleData = doubleData});
+                    break;
+
+                case MilvusDataType.String:
+                    Grpc.StringArray stringData = new();
+                    stringData.Data.AddRange(array as IEnumerable<string>);
+                    arrayArray.Data.Add(new ScalarField {StringData = stringData});
+                    break;
+
+                case MilvusDataType.VarChar:
+                    Grpc.StringArray varcharData = new();
+                    varcharData.Data.AddRange(array as IEnumerable<string>);
+                    arrayArray.Data.Add(new ScalarField {StringData = varcharData});
+                    break;
+
+                case MilvusDataType.Json:
+                    Grpc.JSONArray jsonData = new();
+                    var enumerable = array as IEnumerable<string> ?? Enumerable.Empty<string>();
+                    jsonData.Data.AddRange(enumerable.Select(ByteString.CopyFromUtf8));
+                    arrayArray.Data.Add(new ScalarField {JsonData = jsonData});
+                    break;
+                case MilvusDataType.None:
+                    throw new MilvusException($"ElementType Error:{DataType}");
+                default:
+                    throw new MilvusException($"ElementType Error:{DataType}, not supported");
+            }
+        }
+
+        return fieldData;
+
+        /*
+        int dataCount = Data.Count;
+        if (dataCount == 0)
+        {
+            throw new MilvusException("The number of vectors must be positive.");
+        }
+
+        int vectorByteLength = Data[0].Length;
+        int totalByteLength = vectorByteLength;
+        for (int i = 1; i < dataCount; i++)
+        {
+            int rowLength = Data[i].Length;
+            if (rowLength != vectorByteLength)
+            {
+                throw new MilvusException("All vectors must have the same dimensionality.");
+            }
+
+            checked { totalByteLength += rowLength; }
+        }
+
+        byte[] bytes = ArrayPool<byte>.Shared.Rent(totalByteLength);
+        int pos = 0;
+        for (int i = 0; i < dataCount; i++)
+        {
+            ReadOnlyMemory<byte> row = Data[i];
+            row.Span.CopyTo(bytes.AsSpan(pos, row.Length));
+            pos += row.Length;
+        }
+        Debug.Assert(pos == totalByteLength);
+
+        var result = new Grpc.FieldData
+        {
+            FieldName = FieldName,
+            Type = (Grpc.DataType)DataType,
+            Vectors = new Grpc.VectorField
+            {
+                BinaryVector = ByteString.CopyFrom(bytes.AsSpan(0, totalByteLength)),
+                Dim = vectorByteLength * 8,
+            }
+        };
+
+        ArrayPool<byte>.Shared.Return(bytes);
+        */
+    }
+
+    internal override object GetValueAsObject(int index)
+        => ElementType switch
+        {
+            MilvusDataType.Bool => ((IReadOnlyList<IEnumerable<bool>>) Data)[index],
+            MilvusDataType.Int8 => ((IReadOnlyList<IEnumerable<sbyte>>) Data)[index],
+            MilvusDataType.Int16 => ((IReadOnlyList<IEnumerable<short>>) Data)[index],
+            MilvusDataType.Int32 => ((IReadOnlyList<IEnumerable<int>>) Data)[index],
+            MilvusDataType.Int64 => ((IReadOnlyList<IEnumerable<long>>) Data)[index],
+            MilvusDataType.Float => ((IReadOnlyList<IEnumerable<float>>) Data)[index],
+            MilvusDataType.Double => ((IReadOnlyList<IEnumerable<double>>) Data)[index],
+            MilvusDataType.String => ((IReadOnlyList<IEnumerable<string>>) Data)[index],
+            MilvusDataType.VarChar => ((IReadOnlyList<IEnumerable<string>>) Data)[index],
+
+            MilvusDataType.None => throw new MilvusException($"DataType Error:{DataType}"),
+            _ => throw new MilvusException($"DataType Error:{DataType}, not supported")
+        };
+}

--- a/Milvus.Client/Constants.cs
+++ b/Milvus.Client/Constants.cs
@@ -71,6 +71,11 @@ internal static class Constants
     internal const string FailedReason = "failed_reason";
 
     /// <summary>
+    /// Key name.
+    /// </summary>
+    internal const string MaxCapacity = "max_capacity";
+
+    /// <summary>
     /// Files.
     /// </summary>
     internal const string ImportFiles = "files";

--- a/Milvus.Client/FieldData.cs
+++ b/Milvus.Client/FieldData.cs
@@ -122,39 +122,39 @@ public abstract class FieldData
             case Grpc.FieldData.FieldOneofCase.Scalars:
                 return fieldData.Scalars switch
                 {
-                    {DataCase: ScalarField.DataOneofCase.BoolData}
+                    { DataCase: ScalarField.DataOneofCase.BoolData }
                         => Create(fieldData.FieldName, fieldData.Scalars.BoolData.Data, fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.FloatData}
+                    { DataCase: ScalarField.DataOneofCase.FloatData }
                         => Create(fieldData.FieldName, fieldData.Scalars.FloatData.Data, fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.IntData}
+                    { DataCase: ScalarField.DataOneofCase.IntData }
                         => Create(fieldData.FieldName, fieldData.Scalars.IntData.Data, fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.LongData}
+                    { DataCase: ScalarField.DataOneofCase.LongData }
                         => Create(fieldData.FieldName, fieldData.Scalars.LongData.Data, fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.StringData}
+                    { DataCase: ScalarField.DataOneofCase.StringData }
                         => CreateVarChar(fieldData.FieldName, fieldData.Scalars.StringData.Data, fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.JsonData}
+                    { DataCase: ScalarField.DataOneofCase.JsonData }
                         => CreateJson(fieldData.FieldName, fieldData.Scalars.JsonData.Data.Select(p => p.ToStringUtf8()).ToList(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Bool}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Bool }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.BoolData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int8}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int8 }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int16}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int16 }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int32}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int32 }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int64}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int64 }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.LongData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Float}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Float }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.FloatData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Double}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Double }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.DoubleData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.String}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.String }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.VarChar}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.VarChar }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data).ToArray(), fieldData.IsDynamic),
-                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Json}
+                    { DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Json }
                         => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.JsonData.Data).ToArray(), fieldData.IsDynamic),
-                    _ => throw new NotSupportedException($"{fieldData.Scalars.DataCase} not support"),
+                    _ => throw new NotSupportedException($"{ fieldData.Scalars.DataCase } not support"),
                 };
 
             default:

--- a/Milvus.Client/FieldData.cs
+++ b/Milvus.Client/FieldData.cs
@@ -13,7 +13,7 @@ public abstract class FieldData
     /// </summary>
     /// <param name="fieldName">Field name.</param>
     /// <param name="dataType">Field data type.</param>
-    /// <param name="isDynamic"></param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
     protected FieldData(string fieldName, MilvusDataType dataType, bool isDynamic = false)
     {
         FieldName = fieldName;
@@ -120,22 +120,40 @@ public abstract class FieldData
                 }
 
             case Grpc.FieldData.FieldOneofCase.Scalars:
-                return fieldData.Scalars.DataCase switch
+                return fieldData.Scalars switch
                 {
-                    Grpc.ScalarField.DataOneofCase.BoolData
+                    {DataCase: ScalarField.DataOneofCase.BoolData}
                         => Create(fieldData.FieldName, fieldData.Scalars.BoolData.Data, fieldData.IsDynamic),
-                    Grpc.ScalarField.DataOneofCase.FloatData
+                    {DataCase: ScalarField.DataOneofCase.FloatData}
                         => Create(fieldData.FieldName, fieldData.Scalars.FloatData.Data, fieldData.IsDynamic),
-                    Grpc.ScalarField.DataOneofCase.IntData
+                    {DataCase: ScalarField.DataOneofCase.IntData}
                         => Create(fieldData.FieldName, fieldData.Scalars.IntData.Data, fieldData.IsDynamic),
-                    Grpc.ScalarField.DataOneofCase.LongData
+                    {DataCase: ScalarField.DataOneofCase.LongData}
                         => Create(fieldData.FieldName, fieldData.Scalars.LongData.Data, fieldData.IsDynamic),
-                    Grpc.ScalarField.DataOneofCase.StringData
+                    {DataCase: ScalarField.DataOneofCase.StringData}
                         => CreateVarChar(fieldData.FieldName, fieldData.Scalars.StringData.Data, fieldData.IsDynamic),
-                    Grpc.ScalarField.DataOneofCase.JsonData
-                        => CreateJson(fieldData.FieldName, fieldData.Scalars.JsonData.Data
-                            .Select(p => p.ToStringUtf8()).ToList(), fieldData.IsDynamic),
-
+                    {DataCase: ScalarField.DataOneofCase.JsonData}
+                        => CreateJson(fieldData.FieldName, fieldData.Scalars.JsonData.Data.Select(p => p.ToStringUtf8()).ToList(), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Bool}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.BoolData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int8}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int16}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int32}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int64}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.LongData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Float}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.FloatData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Double}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.DoubleData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.String}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.VarChar}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data), fieldData.IsDynamic),
+                    {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Json}
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.JsonData.Data), fieldData.IsDynamic),
                     _ => throw new NotSupportedException($"{fieldData.Scalars.DataCase} not support"),
                 };
 
@@ -227,14 +245,29 @@ public abstract class FieldData
     /// Create a varchar field.
     /// </summary>
     /// <param name="fieldName">Field name.</param>
-    /// <param name="data">Data.</param>
-    /// <param name="isDynamic"></param>
+    /// <param name="data">Data in this field</param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
     /// <returns></returns>
     public static FieldData<string> CreateVarChar(
         string fieldName,
         IReadOnlyList<string> data,
         bool isDynamic = false)
         => new(fieldName, data, MilvusDataType.VarChar, isDynamic);
+
+    /// <summary>
+    /// Create array of elements.
+    /// </summary>
+    /// <param name="fieldName">Field name.</param>
+    /// <param name="data">Data in this field</param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
+    /// <returns></returns>
+    public static ArrayFieldData<TElement> CreateArray<TElement>(
+        string fieldName,
+        IEnumerable<IEnumerable<TElement>> data,
+        bool isDynamic = false)
+    {
+        return new(fieldName, data, isDynamic);
+    }
 
     /// <summary>
     /// Create a field from <see cref="byte"/> array.
@@ -267,8 +300,8 @@ public abstract class FieldData
     /// <summary>
     /// Create a binary vectors
     /// </summary>
-    /// <param name="fieldName"></param>
-    /// <param name="data"></param>
+    /// <param name="fieldName">Field name.</param>
+    /// <param name="data">Data in this field</param>
     /// <returns></returns>
     public static BinaryVectorFieldData CreateBinaryVectors(string fieldName, IReadOnlyList<ReadOnlyMemory<byte>> data)
     {
@@ -281,7 +314,7 @@ public abstract class FieldData
     /// Create a float vector.
     /// </summary>
     /// <param name="fieldName">Field name.</param>
-    /// <param name="data">Data</param>
+    /// <param name="data">Data in this field</param>
     /// <returns></returns>
     public static FloatVectorFieldData CreateFloatVector(string fieldName, IReadOnlyList<ReadOnlyMemory<float>> data)
         => new(fieldName, data);
@@ -290,7 +323,7 @@ public abstract class FieldData
     /// Create a field from stream
     /// </summary>
     /// <param name="fieldName">Field name</param>
-    /// <param name="stream"></param>
+    /// <param name="stream">Stream data</param>
     /// <param name="dimension">Dimension of data</param>
     /// <returns>New created field</returns>
     public static FieldData CreateFromStream(string fieldName, Stream stream, long dimension)
@@ -305,8 +338,8 @@ public abstract class FieldData
     /// Create json field.
     /// </summary>
     /// <param name="fieldName">Field name.</param>
-    /// <param name="json">json field.</param>
-    /// <param name="isDynamic"></param>
+    /// <param name="json">Json field.</param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
     /// <returns></returns>
     public static FieldData CreateJson(string fieldName, IReadOnlyList<string> json, bool isDynamic = false)
     {
@@ -324,9 +357,9 @@ public class FieldData<TData> : FieldData
     /// <summary>
     /// Construct a field
     /// </summary>
-    /// <param name="fieldName"></param>
-    /// <param name="data"></param>
-    /// <param name="isDynamic"></param>
+    /// <param name="fieldName">Field name.</param>
+    /// <param name="data">Data in this field</param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
     public FieldData(string fieldName, IReadOnlyList<TData> data, bool isDynamic = false)
         : base(fieldName, EnsureDataType<TData>(), isDynamic)
         => Data = data;
@@ -334,10 +367,10 @@ public class FieldData<TData> : FieldData
     /// <summary>
     /// Construct a field
     /// </summary>
-    /// <param name="fieldName"></param>
-    /// <param name="data"></param>
+    /// <param name="fieldName">Field name.</param>
+    /// <param name="data">Data in this field</param>
     /// <param name="milvusDataType">Milvus data type.</param>
-    /// <param name="isDynamic"></param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
     public FieldData(string fieldName, IReadOnlyList<TData> data, MilvusDataType milvusDataType, bool isDynamic)
         : base(fieldName, milvusDataType, isDynamic)
         => Data = data;
@@ -446,7 +479,6 @@ public class FieldData<TData> : FieldData
                 }
                 fieldData.Scalars = new Grpc.ScalarField { JsonData = jsonData, };
                 break;
-
             case MilvusDataType.None:
                 throw new MilvusException($"DataType Error:{DataType}");
             default:
@@ -481,7 +513,11 @@ public class FieldData<TData> : FieldData
     public override string ToString()
         => $"Field: {{{nameof(FieldName)}: {FieldName}, {nameof(DataType)}: {DataType}, {nameof(Data)}: {Data?.Count}, {nameof(RowCount)}: {RowCount}}}";
 
-    private void Check()
+    /// <summary>
+    /// Checks data
+    /// </summary>
+    /// <exception cref="MilvusException"></exception>
+    protected void Check()
     {
         if (Data.Any() != true)
         {

--- a/Milvus.Client/FieldData.cs
+++ b/Milvus.Client/FieldData.cs
@@ -135,25 +135,25 @@ public abstract class FieldData
                     {DataCase: ScalarField.DataOneofCase.JsonData}
                         => CreateJson(fieldData.FieldName, fieldData.Scalars.JsonData.Data.Select(p => p.ToStringUtf8()).ToList(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Bool}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.BoolData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.BoolData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int8}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int16}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int32}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.IntData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Int64}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.LongData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.LongData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Float}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.FloatData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.FloatData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Double}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.DoubleData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.DoubleData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.String}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.VarChar}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.StringData.Data).ToArray(), fieldData.IsDynamic),
                     {DataCase: ScalarField.DataOneofCase.ArrayData, ArrayData.ElementType: Grpc.DataType.Json}
-                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.JsonData.Data), fieldData.IsDynamic),
+                        => CreateArray(fieldData.FieldName, fieldData.Scalars.ArrayData.Data.Select(x => x.JsonData.Data).ToArray(), fieldData.IsDynamic),
                     _ => throw new NotSupportedException($"{fieldData.Scalars.DataCase} not support"),
                 };
 
@@ -165,7 +165,7 @@ public abstract class FieldData
     internal static MilvusDataType EnsureDataType<TDataType>()
     {
         Type type = typeof(TDataType);
-        MilvusDataType dataType = MilvusDataType.None;
+        MilvusDataType dataType;
 
         if (type == typeof(bool))
         {
@@ -263,7 +263,7 @@ public abstract class FieldData
     /// <returns></returns>
     public static ArrayFieldData<TElement> CreateArray<TElement>(
         string fieldName,
-        IEnumerable<IEnumerable<TElement>> data,
+        IReadOnlyList<IReadOnlyList<TElement>> data,
         bool isDynamic = false)
     {
         return new(fieldName, data, isDynamic);

--- a/Milvus.Client/FieldData.cs
+++ b/Milvus.Client/FieldData.cs
@@ -165,7 +165,7 @@ public abstract class FieldData
     internal static MilvusDataType EnsureDataType<TDataType>()
     {
         Type type = typeof(TDataType);
-        MilvusDataType dataType = MilvusDataType.Double;
+        MilvusDataType dataType = MilvusDataType.None;
 
         if (type == typeof(bool))
         {
@@ -209,7 +209,7 @@ public abstract class FieldData
         }
         else
         {
-            throw new NotSupportedException($"Not Support DataType:{dataType}");
+            throw new NotSupportedException($"Type {type.Name} cannot be mapped to DataType");
         }
 
         return dataType;

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -95,6 +95,43 @@ public sealed class FieldSchema
     public static FieldSchema CreateJson(string name)
         => new(name, MilvusDataType.Json);
 
+    /// <summary>
+    /// Create a field schema for a <c>array</c> of <c>TData</c> field.
+    /// </summary>
+    /// <typeparam name="TData">Determines the element data type of array stored in the field based.</typeparam>
+    /// <param name="name">The field name.</param>
+    /// <param name="capacity">Maximum number of elements that an array field can contain.</param>
+    /// <param name="description">An optional description for the field.</param>
+    public static FieldSchema CreateArray<TData>(
+        string name,
+        int capacity,
+        string description = "")
+        => new(name, MilvusDataType.Array, description: description)
+        {
+            ElementDataType = FieldData.EnsureDataType<TData>(),
+            MaxCapacity = capacity,
+        };
+
+    /// <summary>
+    /// Create a field schema for a <c>array</c> of <c>varchar</c> field.
+    /// </summary>
+    /// <param name="name">The field name.</param>
+    /// <param name="capacity">Maximum number of elements that an array field can contain.</param>
+    /// <param name="maxLength">Maximum length of strings for each <c>varchar</c> element in an array field.</param>
+    /// <param name="description">An optional description for the field.</param>
+    public static FieldSchema CreateVarcharArray(
+        string name,
+        int capacity,
+        int maxLength,
+        string description = "")
+        => new(name, MilvusDataType.Array, description: description)
+        {
+            ElementDataType = MilvusDataType.VarChar,
+            MaxCapacity = capacity,
+            MaxLength = maxLength,
+            
+        };
+
     // Construct used when the user constructs a schema to be provided to CreateSchema
     private FieldSchema(
         string name,
@@ -118,6 +155,7 @@ public sealed class FieldSchema
         long id,
         string name,
         MilvusDataType dataType,
+        MilvusDataType elementType,
         FieldState state,
         bool isPrimaryKey,
         bool autoId,
@@ -128,6 +166,7 @@ public sealed class FieldSchema
         FieldId = id;
         Name = name;
         DataType = dataType;
+        ElementDataType = elementType;
         State = state;
         IsPrimaryKey = isPrimaryKey;
         AutoId = autoId;
@@ -145,6 +184,11 @@ public sealed class FieldSchema
     /// The data type stored in the field.
     /// </summary>
     public MilvusDataType DataType { get; }
+
+    /// <summary>
+    /// The element data type for array stored in the field.
+    /// </summary>
+    public MilvusDataType ElementDataType { get; set; }
 
     /// <summary>
     /// Whether the field is a primary key.
@@ -186,6 +230,11 @@ public sealed class FieldSchema
     /// zero.
     /// </summary>
     public int? MaxLength { get; set; }
+
+    /// <summary>
+    /// Maximum number of elements that an array field can contain. Mandatory for <see cref="MilvusDataType.Array" /> fields, and must be in a range [1, 4096]
+    /// </summary>
+    public int? MaxCapacity { get; set; }
 
     /// <summary>
     /// The dimension of the vector. Mandatory for <see cref="MilvusDataType.FloatVector" />

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -100,34 +100,34 @@ public sealed class FieldSchema
     /// </summary>
     /// <typeparam name="TData">Determines the element data type of array stored in the field based.</typeparam>
     /// <param name="name">The field name.</param>
-    /// <param name="capacity">Maximum number of elements that an array field can contain.</param>
+    /// <param name="maxCapacity">Maximum number of elements that an array field can contain.</param>
     /// <param name="description">An optional description for the field.</param>
     public static FieldSchema CreateArray<TData>(
         string name,
-        int capacity,
+        int maxCapacity,
         string description = "")
         => new(name, MilvusDataType.Array, description: description)
         {
             ElementDataType = FieldData.EnsureDataType<TData>(),
-            MaxCapacity = capacity,
+            MaxCapacity = maxCapacity,
         };
 
     /// <summary>
     /// Create a field schema for a <c>array</c> of <c>varchar</c> field.
     /// </summary>
     /// <param name="name">The field name.</param>
-    /// <param name="capacity">Maximum number of elements that an array field can contain.</param>
+    /// <param name="maxCapacity">Maximum number of elements that an array field can contain.</param>
     /// <param name="maxLength">Maximum length of strings for each <c>varchar</c> element in an array field.</param>
     /// <param name="description">An optional description for the field.</param>
     public static FieldSchema CreateVarcharArray(
         string name,
-        int capacity,
+        int maxCapacity,
         int maxLength,
         string description = "")
         => new(name, MilvusDataType.Array, description: description)
         {
             ElementDataType = MilvusDataType.VarChar,
-            MaxCapacity = capacity,
+            MaxCapacity = maxCapacity,
             MaxLength = maxLength,
         };
 

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -129,7 +129,6 @@ public sealed class FieldSchema
             ElementDataType = MilvusDataType.VarChar,
             MaxCapacity = capacity,
             MaxLength = maxLength,
-            
         };
 
     // Construct used when the user constructs a schema to be provided to CreateSchema

--- a/Milvus.Client/Milvus.Client.csproj
+++ b/Milvus.Client/Milvus.Client.csproj
@@ -33,7 +33,6 @@
     <Protobuf Include="Protos\proto\milvus.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
     <Protobuf Include="Protos\proto\msg.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
     <Protobuf Include="Protos\proto\feder.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
-    <Protobuf Include="Protos\proto\rg.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Milvus.Client/Milvus.Client.csproj
+++ b/Milvus.Client/Milvus.Client.csproj
@@ -14,7 +14,6 @@
     <PackageTags>milvus;vector database</PackageTags>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Milvus.Client/Milvus.Client.csproj
+++ b/Milvus.Client/Milvus.Client.csproj
@@ -34,6 +34,7 @@
     <Protobuf Include="Protos\proto\milvus.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
     <Protobuf Include="Protos\proto\msg.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
     <Protobuf Include="Protos\proto\feder.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
+    <Protobuf Include="Protos\proto\rg.proto" GrpcServices="Client" ProtoRoot="Protos\proto" Access="internal" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Milvus.Client/Milvus.Client.csproj
+++ b/Milvus.Client/Milvus.Client.csproj
@@ -14,6 +14,7 @@
     <PackageTags>milvus;vector database</PackageTags>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Milvus.Client/MilvusClient.Collection.cs
+++ b/Milvus.Client/MilvusClient.Collection.cs
@@ -87,6 +87,7 @@ public partial class MilvusClient
             {
                 Name = field.Name,
                 DataType = (DataType)(int)field.DataType,
+                ElementType = (DataType)(int)field.ElementDataType,
                 IsPrimaryKey = field.IsPrimaryKey,
                 IsPartitionKey = field.IsPartitionKey,
                 AutoID = field.AutoId,
@@ -108,6 +109,15 @@ public partial class MilvusClient
                 {
                     Key = Constants.VectorDim,
                     Value = field.Dimension.Value.ToString(CultureInfo.InvariantCulture)
+                });
+            }
+
+            if (field.MaxCapacity is not null)
+            {
+                grpcField.TypeParams.Add(new Grpc.KeyValuePair
+                {
+                    Key = Constants.MaxCapacity,
+                    Value = field.MaxCapacity.Value.ToString(CultureInfo.InvariantCulture)
                 });
             }
 

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -34,9 +34,16 @@ public partial class MilvusCollection
         foreach (Grpc.FieldSchema grpcField in response.Schema.Fields)
         {
             FieldSchema milvusField = new(
-                grpcField.FieldID, grpcField.Name, (MilvusDataType)grpcField.DataType,
-                (FieldState)grpcField.State, grpcField.IsPrimaryKey, grpcField.AutoID, grpcField.IsPartitionKey,
-                grpcField.IsDynamic, grpcField.Description);
+                grpcField.FieldID,
+                grpcField.Name,
+                (MilvusDataType) grpcField.DataType,
+                (MilvusDataType) grpcField.ElementType,
+                (FieldState) grpcField.State,
+                grpcField.IsPrimaryKey,
+                grpcField.AutoID,
+                grpcField.IsPartitionKey,
+                grpcField.IsDynamic,
+                grpcField.Description);
 
             foreach (Grpc.KeyValuePair parameter in grpcField.TypeParams)
             {
@@ -44,6 +51,10 @@ public partial class MilvusCollection
                 {
                     case Constants.VarcharMaxLength:
                         milvusField.MaxLength = int.Parse(parameter.Value, CultureInfo.InvariantCulture);
+                        break;
+
+                    case Constants.MaxCapacity:
+                        milvusField.MaxCapacity = int.Parse(parameter.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case Constants.VectorDim:


### PR DESCRIPTION
This PR introduces support for [Array](https://milvus.io/docs/array_data_type.md#Array) fields, encompassing schema definitions as well as data requests, inserts, and upserts.

I have authored a series of unit tests to cover various array types.

Additionally, the Proto submodule has been upgraded to [v2.4](https://github.com/milvus-io/milvus-proto/tree/2.4).

Fixes #77