### PR TITLE
Fix build and parallel-execution race on main

### DIFF
--- a/Milvus.Client.Tests/Bm25Tests.cs
+++ b/Milvus.Client.Tests/Bm25Tests.cs
@@ -2,7 +2,6 @@ using Xunit;
 
 namespace Milvus.Client.Tests;
 
-[Collection("Milvus")]
 public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
 {
     private readonly MilvusClient Client = milvusFixture.CreateClient();

--- a/Milvus.Client.Tests/Bm25Tests.cs
+++ b/Milvus.Client.Tests/Bm25Tests.cs
@@ -16,7 +16,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_full_text_search));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -32,12 +32,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.CreateIndexAsync(
             "sparse_vector",
             IndexType.SparseInvertedIndex,
-            SimilarityMetricType.Bm25);
+            SimilarityMetricType.Bm25,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -48,12 +49,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 "A fast orange cat leaps across the sleepy hound",
                 "Hello world, this is a test document"
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.SearchAsync(
             "sparse_vector",
@@ -63,7 +65,8 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             {
                 ConsistencyLevel = ConsistencyLevel.Strong,
                 OutputFields = { "text" }
-            });
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count > 0);
@@ -83,7 +86,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_search_returns_correct_scores));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -99,12 +102,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.CreateIndexAsync(
             "bm25_vector",
             IndexType.SparseInvertedIndex,
-            SimilarityMetricType.Bm25);
+            SimilarityMetricType.Bm25,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -116,18 +120,20 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 "natural language processing and text classification",
                 "the weather today is sunny and warm"
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.SearchAsync(
             "bm25_vector",
             new[] { "learning" },
             limit: 4,
-            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong });
+            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count >= 2);
@@ -147,7 +153,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_multiple_queries));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -163,12 +169,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.CreateIndexAsync(
             "doc_vector",
             IndexType.SparseInvertedIndex,
-            SimilarityMetricType.Bm25);
+            SimilarityMetricType.Bm25,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -179,18 +186,20 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 "car truck motorcycle vehicle transportation",
                 "computer laptop smartphone technology gadget"
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.SearchAsync(
             "doc_vector",
             new[] { "fruit", "vehicle" },
             limit: 2,
-            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong });
+            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.Equal(2, results.NumQueries);
@@ -205,7 +214,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Describe_collection_with_bm25_function));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -226,9 +235,9 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
-        var description = await collection.DescribeAsync();
+        var description = await collection.DescribeAsync(TestContext.Current.CancellationToken);
 
         Assert.Single(description.Schema.Functions);
         var function = description.Schema.Functions[0];
@@ -258,7 +267,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_with_filter_expression));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -275,12 +284,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.CreateIndexAsync(
             "title_vector",
             IndexType.SparseInvertedIndex,
-            SimilarityMetricType.Bm25);
+            SimilarityMetricType.Bm25,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -293,12 +303,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 "introduction to cooking",
                 "advanced cooking recipes"
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.SearchAsync(
             "title_vector",
@@ -309,7 +320,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 ConsistencyLevel = ConsistencyLevel.Strong,
                 Expression = "category == 1",
                 OutputFields = { "title", "category" }
-            });
+            }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.Equal(2, results.Ids.LongIds.Count);
@@ -327,7 +338,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_hybrid_search_with_dense_vector));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -344,10 +355,10 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.CreateIndexAsync("title_sparse", IndexType.SparseInvertedIndex, SimilarityMetricType.Bm25);
-        await collection.CreateIndexAsync("embedding", IndexType.Flat, SimilarityMetricType.L2);
+        await collection.CreateIndexAsync("title_sparse", IndexType.SparseInvertedIndex, SimilarityMetricType.Bm25, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.CreateIndexAsync("embedding", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -366,12 +377,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 new[] { 0.0f, 0.0f, 1.0f, 0.0f },
                 new[] { 0.5f, 0.0f, 0.5f, 0.0f }
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.HybridSearchAsync(
             [
@@ -388,7 +400,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             {
                 ConsistencyLevel = ConsistencyLevel.Strong,
                 OutputFields = { "title" }
-            });
+            }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count > 0);
@@ -408,7 +420,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_with_english_analyzer));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -428,9 +440,9 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
-        var description = await collection.DescribeAsync();
+        var description = await collection.DescribeAsync(TestContext.Current.CancellationToken);
         var textField = description.Schema.Fields.Single(f => f.Name == "text");
         Assert.True(textField.EnableAnalyzer);
         Assert.NotNull(textField.AnalyzerParams);
@@ -439,7 +451,8 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         await collection.CreateIndexAsync(
             "sparse_vector",
             IndexType.SparseInvertedIndex,
-            SimilarityMetricType.Bm25);
+            SimilarityMetricType.Bm25,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -450,12 +463,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 "A dog runs in the park",
                 "Hello world"
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // English analyzer stems words, so "running" should match "runs"
         var results = await collection.SearchAsync(
@@ -466,7 +480,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             {
                 ConsistencyLevel = ConsistencyLevel.Strong,
                 OutputFields = { "text" }
-            });
+            }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count >= 2);
@@ -481,7 +495,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_with_custom_index_parameters));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -497,7 +511,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.CreateIndexAsync(
             "sparse_vector",
@@ -508,7 +522,8 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 ["inverted_index_algo"] = "\"DAAT_WAND\"",
                 ["bm25_k1"] = "1.5",
                 ["bm25_b"] = "0.75"
-            });
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -519,12 +534,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 "A fast orange cat leaps across the sleepy hound",
                 "Hello world, this is a test document"
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.SearchAsync(
             "sparse_vector",
@@ -534,7 +550,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             {
                 ConsistencyLevel = ConsistencyLevel.Strong,
                 OutputFields = { "text" }
-            });
+            }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count > 0);
@@ -550,7 +566,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
         }
 
         MilvusCollection collection = Client.GetCollection(nameof(Bm25_hybrid_search_with_weighted_reranker));
-        await collection.DropAsync();
+        await collection.DropAsync(TestContext.Current.CancellationToken);
 
         var schema = new CollectionSchema
         {
@@ -567,10 +583,10 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             }
         };
 
-        await Client.CreateCollectionAsync(collection.Name, schema);
+        await Client.CreateCollectionAsync(collection.Name, schema, cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.CreateIndexAsync("content_sparse", IndexType.SparseInvertedIndex, SimilarityMetricType.Bm25);
-        await collection.CreateIndexAsync("content_embedding", IndexType.Flat, SimilarityMetricType.L2);
+        await collection.CreateIndexAsync("content_sparse", IndexType.SparseInvertedIndex, SimilarityMetricType.Bm25, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.CreateIndexAsync("content_embedding", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
 
         await collection.InsertAsync(
         [
@@ -587,12 +603,13 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
                 new[] { 0.0f, 1.0f },
                 new[] { 0.8f, 0.2f }
             })
-        ]);
+        ], cancellationToken: TestContext.Current.CancellationToken);
 
-        await collection.LoadAsync();
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
         await collection.WaitForCollectionLoadAsync(
             waitingInterval: TimeSpan.FromMilliseconds(100),
-            timeout: TimeSpan.FromMinutes(1));
+            timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         var results = await collection.HybridSearchAsync(
             [
@@ -605,7 +622,8 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             ],
             new WeightedReranker(0.7f, 0.3f),
             limit: 3,
-            new HybridSearchParameters { ConsistencyLevel = ConsistencyLevel.Strong });
+            new HybridSearchParameters { ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count > 0);

--- a/Milvus.Client.Tests/Bm25Tests.cs
+++ b/Milvus.Client.Tests/Bm25Tests.cs
@@ -64,8 +64,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             {
                 ConsistencyLevel = ConsistencyLevel.Strong,
                 OutputFields = { "text" }
-            },
-            cancellationToken: TestContext.Current.CancellationToken);
+            }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count > 0);
@@ -131,8 +130,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             "bm25_vector",
             new[] { "learning" },
             limit: 4,
-            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong },
-            cancellationToken: TestContext.Current.CancellationToken);
+            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count >= 2);
@@ -197,8 +195,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             "doc_vector",
             new[] { "fruit", "vehicle" },
             limit: 2,
-            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong },
-            cancellationToken: TestContext.Current.CancellationToken);
+            new SearchParameters { ConsistencyLevel = ConsistencyLevel.Strong }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.Equal(2, results.NumQueries);
@@ -621,8 +618,7 @@ public class Bm25Tests(MilvusFixture milvusFixture) : IDisposable
             ],
             new WeightedReranker(0.7f, 0.3f),
             limit: 3,
-            new HybridSearchParameters { ConsistencyLevel = ConsistencyLevel.Strong },
-            cancellationToken: TestContext.Current.CancellationToken);
+            new HybridSearchParameters { ConsistencyLevel = ConsistencyLevel.Strong }, TestContext.Current.CancellationToken);
 
         Assert.NotNull(results.Ids.LongIds);
         Assert.True(results.Ids.LongIds.Count > 0);

--- a/Milvus.Client.Tests/DataTests.cs
+++ b/Milvus.Client.Tests/DataTests.cs
@@ -2,6 +2,14 @@ using Xunit;
 
 namespace Milvus.Client.Tests;
 
+// FlushAllAsync_and_wait calls the cluster-wide FlushAll, which enumerates and flushes every
+// collection in the instance. All the other test classes create and drop collections, so if any of
+// them runs concurrently the flush fails with "collection not found". Keep this class out of the
+// parallel pool so the global flush sees a stable set of collections.
+[CollectionDefinition(nameof(DataTests), DisableParallelization = true)]
+public sealed class DataTestsCollection;
+
+[Collection(nameof(DataTests))]
 public class DataTests : IClassFixture<DataTests.DataCollectionFixture>, IAsyncLifetime
 {
     [Fact]


### PR DESCRIPTION
## Problem

`main` is red. Two separate post-merge problems, both fallout from #134 and #136 landing together.

### 1. Build failure — 62 × `xUnit1051` in `Bm25Tests.cs`

```
Bm25Tests.cs(19,15): error xUnit1051: Calls to methods which accept CancellationToken
should use TestContext.Current.CancellationToken ...
```

A semantic merge conflict between two PRs that were each green alone:

- **#134 (BM25)** added `Bm25Tests.cs`, written against xunit v2 — no `TestContext.Current.CancellationToken`.
- **#136 (xunit.v3)** enabled the `xUnit1051` analyzer, which is a **build error** here because `TreatWarningsAsErrors` is on.

`Bm25Tests.cs` did not exist when #136 was written, so its call sites were never migrated. Git merged both cleanly; the rule from #136 then applied to the new file from #134.

This broke **all four** matrix versions — the reported v2.4.23 job merely failed first, and fail-fast cancelled the rest.

### 2. Test failure — `DataTests.FlushAllAsync_and_wait`

```
ErrorCode: 65535 ... failed to call flush all to data coordinator: collection not found
```

`FlushAll` is cluster-wide: it enumerates and flushes every collection in the instance. Every other test class creates and drops collections, so once #136 made the classes run in parallel, this test could see a collection disappear mid-flush.

It is timing-dependent — it failed on v2.5.20 while v2.3.22 and v2.6.4 passed. It surfaced now because this was the first run after #136 in which the build got far enough to execute tests.

## Fix

1. Thread `TestContext.Current.CancellationToken` through all 62 call sites in `Bm25Tests.cs`. Named `cancellationToken:` is used **only** where an intermediate optional parameter is skipped (e.g. `CreateIndexAsync` passing `extraParams:` without `indexName`, `CreateCollectionAsync` skipping `consistencyLevel`/`shardsNum`, `InsertAsync` skipping `partitionName`); positional everywhere else. This item carries no behavioural change.
2. Put `DataTests` in a collection with `DisableParallelization` so the global flush sees a stable set of collections.
3. Drop the now-dangling `[Collection("Milvus")]` from `Bm25Tests` — #136 removed the matching `MilvusTestCollection` definition.

> **Scope note:** items 2 and 3 *are* behavioural changes to the test suite — `DataTests` no longer runs concurrently with the other classes. That is deliberate (the cluster-wide `FlushAll` needs a stable set of collections), but it is a real change in how the suite executes, not a mechanical token edit.

## Verification

- Build: clean, 0 errors / 0 warnings, all TFMs
- `Bm25Tests` against Milvus v2.6.4: **9/9 passing**
- Full suite against v2.6.4, run **twice** to check the race actually holds: **200 passed, 1 skipped, 0 failed** both times (the skip is the pre-existing `Query_with_time_travel`)
