### PR TITLE
Add AddCollectionField, AlterCollectionField, and collection-function management

### DIFF
--- a/Milvus.Client.Tests/SchemaEvolutionTests.cs
+++ b/Milvus.Client.Tests/SchemaEvolutionTests.cs
@@ -112,11 +112,16 @@ public class SchemaEvolutionTests(MilvusFixture milvusFixture) : IAsyncLifetime
 
         MilvusCollection collection = await CreateCollectionAsync(nameof(AddCollectionField_rejects_a_vector_field));
 
-        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
-            collection.AddCollectionFieldAsync(
-                FieldSchema.CreateFloatVector("extra_vector", 2), TestContext.Current.CancellationToken));
+        // Nullable, so this is unambiguously testing the vector-type rejection and not the separate
+        // nullable requirement covered by AddCollectionField_requires_nullable above -- on a server whose
+        // request validation checks nullability before field type, a non-nullable vector field here would
+        // be rejected for being non-nullable rather than for being a vector, making the rejection reason
+        // this test cares about untestable.
+        FieldSchema vectorField = FieldSchema.Create("extra_vector", MilvusDataType.FloatVector, nullable: true);
+        vectorField.Dimension = 2;
 
-        Assert.Contains("vector", exception.Message);
+        await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AddCollectionFieldAsync(vectorField, TestContext.Current.CancellationToken));
 
         await collection.DropAsync(TestContext.Current.CancellationToken);
     }

--- a/Milvus.Client.Tests/SchemaEvolutionTests.cs
+++ b/Milvus.Client.Tests/SchemaEvolutionTests.cs
@@ -147,6 +147,148 @@ public class SchemaEvolutionTests(MilvusFixture milvusFixture) : IAsyncLifetime
                 FieldSchema.Create<long?>("extra", nullable: true), TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task AlterCollectionField_increases_varchar_max_length()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateVarcharCollectionAsync(
+            nameof(AlterCollectionField_increases_varchar_max_length), maxLength: 10);
+
+        await collection.AlterCollectionFieldAsync(
+            "text", new Dictionary<string, string> { ["max_length"] = "20" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        MilvusCollectionDescription description = await collection.DescribeAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(20, description.Schema.Fields.Single(f => f.Name == "text").MaxLength);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AlterCollectionField_decreases_varchar_max_length_without_truncating_existing_data()
+    {
+        if (await Skip()) return;
+
+        // Unlike a typical database, Milvus does not validate existing data against a shrunk
+        // max_length: the limit only applies to future writes, so a string already longer than the
+        // new limit survives untouched.
+        MilvusCollection collection = await CreateVarcharCollectionAsync(
+            nameof(AlterCollectionField_decreases_varchar_max_length_without_truncating_existing_data),
+            maxLength: 20);
+
+        await collection.CreateIndexAsync(
+            "vector", IndexType.Flat, SimilarityMetricType.L2, "vector_idx",
+            new Dictionary<string, string>(), TestContext.Current.CancellationToken);
+
+        const string longValue = "this is 18 chars!!";
+        Assert.Equal(18, longValue.Length);
+
+        await collection.InsertAsync(
+            new FieldData[]
+            {
+                FieldData.Create("id", new[] { 1L }),
+                FieldData.CreateVarChar("text", new[] { longValue }),
+                FieldData.CreateFloatVector("vector", new[] { new ReadOnlyMemory<float>(new[] { 1f, 0f }) })
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(
+            waitingInterval: TimeSpan.FromMilliseconds(100), timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.AlterCollectionFieldAsync(
+            "text", new Dictionary<string, string> { ["max_length"] = "5" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var field = (FieldData<string>)await QuerySingleFieldAsync(collection, "text");
+        Assert.Equal(longValue, Assert.Single(field.Data));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AlterCollectionField_sets_and_deletes_a_property()
+    {
+        if (await Skip()) return;
+
+        // mmap.enabled has no observable effect through this SDK's read path (it is a segment loading
+        // hint, not part of FieldSchema), so this only verifies both calls are accepted.
+        MilvusCollection collection =
+            await CreateVarcharCollectionAsync(nameof(AlterCollectionField_sets_and_deletes_a_property), 10);
+
+        await collection.AlterCollectionFieldAsync(
+            "text", new Dictionary<string, string> { ["mmap.enabled"] = "true" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.AlterCollectionFieldAsync(
+            "text", deleteKeys: new[] { "mmap.enabled" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AlterCollectionField_rejects_an_unrecognized_delete_key()
+    {
+        if (await Skip()) return;
+
+        // Rejected because Milvus does not recognize the key name as a field property at all -- not
+        // because it was never set on this field. A recognized key like mmap.enabled can be deleted
+        // even when never set (see the sibling test), so this is a name allow-list, not presence.
+        MilvusCollection collection =
+            await CreateVarcharCollectionAsync(nameof(AlterCollectionField_rejects_an_unrecognized_delete_key), 10);
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AlterCollectionFieldAsync(
+                "text", deleteKeys: new[] { "not_a_real_property" },
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("not_a_real_property", exception.Message);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AlterCollectionField_throws_for_a_field_that_does_not_exist()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection =
+            await CreateVarcharCollectionAsync(nameof(AlterCollectionField_throws_for_a_field_that_does_not_exist), 10);
+
+        await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AlterCollectionFieldAsync(
+                "no_such_field", new Dictionary<string, string> { ["mmap.enabled"] = "true" },
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AlterCollectionField_requires_properties_or_delete_keys()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection(nameof(AlterCollectionField_requires_properties_or_delete_keys));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            collection.AlterCollectionFieldAsync("text", cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AlterCollectionField_throws_for_a_collection_that_does_not_exist()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection("schema_evolution_tests_no_such_collection_2");
+
+        await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AlterCollectionFieldAsync(
+                "text", new Dictionary<string, string> { ["mmap.enabled"] = "true" },
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
     private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 6);
 
     private async Task<FieldData> QuerySingleFieldAsync(
@@ -170,6 +312,23 @@ public class SchemaEvolutionTests(MilvusFixture milvusFixture) : IAsyncLifetime
             new[]
             {
                 FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateFloatVector("vector", 2)
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        return collection;
+    }
+
+    private async Task<MilvusCollection> CreateVarcharCollectionAsync(string name, int maxLength)
+    {
+        MilvusCollection collection = Client.GetCollection(name);
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            name,
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateVarchar("text", maxLength),
                 FieldSchema.CreateFloatVector("vector", 2)
             }, cancellationToken: TestContext.Current.CancellationToken);
 

--- a/Milvus.Client.Tests/SchemaEvolutionTests.cs
+++ b/Milvus.Client.Tests/SchemaEvolutionTests.cs
@@ -1,3 +1,4 @@
+using Grpc.Core;
 using Xunit;
 
 namespace Milvus.Client.Tests;
@@ -287,6 +288,118 @@ public class SchemaEvolutionTests(MilvusFixture milvusFixture) : IAsyncLifetime
             collection.AlterCollectionFieldAsync(
                 "text", new Dictionary<string, string> { ["mmap.enabled"] = "true" },
                 cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AddCollectionFunction_is_currently_rejected_for_bm25()
+    {
+        if (await Skip()) return;
+
+        // AddCollectionFunction cannot succeed today for BM25 -- the only function type this SDK has a
+        // builder for (FunctionSchema.CreateBm25; Rerank and TextEmbedding are enum-only, unbuilt). Two
+        // failure modes were observed empirically, one per server version tested: 2.6.4 does not
+        // implement the RPC at all (RpcException at the gRPC transport level), while 2.6.20 implements
+        // it but explicitly rejects BM25 (MilvusException). Both count as "not usable"; only the second
+        // is checked for content, since the first carries no message to check. If this ever starts
+        // succeeding, the test fails loudly here rather than silently passing.
+        MilvusCollection collection = await CreateBm25ReadyCollectionAsync(
+            nameof(AddCollectionFunction_is_currently_rejected_for_bm25));
+
+        try
+        {
+            await collection.AddCollectionFunctionAsync(
+                FunctionSchema.CreateBm25("bm25_fn", "text", "sparse_vector"),
+                TestContext.Current.CancellationToken);
+
+            Assert.Fail(
+                "AddCollectionFunctionAsync succeeded for a BM25 function. Milvus apparently lifted the " +
+                "restriction documented on AddCollectionFunctionAsync -- update the docs and this test.");
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Unimplemented)
+        {
+            // Milvus 2.6.4: the RPC does not exist yet.
+        }
+        catch (MilvusException e)
+        {
+            Assert.Contains("BM25", e.Message);
+        }
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AlterCollectionFunction_is_currently_rejected_for_bm25()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateBm25ReadyCollectionAsync(
+            nameof(AlterCollectionFunction_is_currently_rejected_for_bm25));
+
+        try
+        {
+            await collection.AlterCollectionFunctionAsync(
+                "bm25_fn", FunctionSchema.CreateBm25("bm25_fn", "text", "sparse_vector"),
+                TestContext.Current.CancellationToken);
+
+            Assert.Fail(
+                "AlterCollectionFunctionAsync succeeded for a BM25 function. Milvus apparently lifted the " +
+                "restriction documented on AlterCollectionFunctionAsync -- update the docs and this test.");
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Unimplemented)
+        {
+            // Milvus 2.6.4: the RPC does not exist yet.
+        }
+        catch (MilvusException e)
+        {
+            Assert.Contains("BM25", e.Message);
+        }
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task DropCollectionFunction_does_not_throw_for_a_function_that_was_never_added()
+    {
+        if (await Skip()) return;
+
+        // Since AddCollectionFunction cannot currently succeed for any function type this SDK can
+        // build (see the sibling tests), there is no way to construct a function that genuinely
+        // exists, so this can only exercise the not-found path. On 2.6.20 that path was observed to
+        // succeed silently rather than throw; on 2.6.4 the RPC is not implemented, so both are treated
+        // as acceptable outcomes here.
+        MilvusCollection collection = await CreateBm25ReadyCollectionAsync(
+            nameof(DropCollectionFunction_does_not_throw_for_a_function_that_was_never_added));
+
+        try
+        {
+            await collection.DropCollectionFunctionAsync("never_added_fn", TestContext.Current.CancellationToken);
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Unimplemented)
+        {
+            // Milvus 2.6.4: the RPC does not exist yet.
+        }
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<MilvusCollection> CreateBm25ReadyCollectionAsync(string name)
+    {
+        MilvusCollection collection = Client.GetCollection(name);
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            name,
+            new CollectionSchema
+            {
+                Fields =
+                {
+                    FieldSchema.Create<long>("id", isPrimaryKey: true),
+                    FieldSchema.CreateVarchar("text", maxLength: 1000, enableAnalyzer: true),
+                    FieldSchema.CreateSparseFloatVector("sparse_vector")
+                }
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        return collection;
     }
 
     private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 6);

--- a/Milvus.Client.Tests/SchemaEvolutionTests.cs
+++ b/Milvus.Client.Tests/SchemaEvolutionTests.cs
@@ -1,0 +1,211 @@
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+public class SchemaEvolutionTests(MilvusFixture milvusFixture) : IAsyncLifetime
+{
+    [Fact]
+    public async Task AddCollectionField_adds_a_nullable_field_to_an_empty_collection()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection =
+            await CreateCollectionAsync(nameof(AddCollectionField_adds_a_nullable_field_to_an_empty_collection));
+
+        await collection.AddCollectionFieldAsync(
+            FieldSchema.Create<long?>("extra", nullable: true), TestContext.Current.CancellationToken);
+
+        MilvusCollectionDescription description = await collection.DescribeAsync(TestContext.Current.CancellationToken);
+        Assert.Contains(description.Schema.Fields, f => f.Name == "extra");
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_requires_nullable()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateCollectionAsync(nameof(AddCollectionField_requires_nullable));
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AddCollectionFieldAsync(
+                FieldSchema.Create<long>("extra"), TestContext.Current.CancellationToken));
+
+        Assert.Contains("nullable", exception.Message);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_requires_nullable_even_with_a_default_value()
+    {
+        if (await Skip()) return;
+
+        // A default value looks like it should be enough to reconcile old rows, but Milvus treats
+        // nullable and defaultValue as independent requirements: this is rejected exactly like the
+        // no-default case above, same error.
+        MilvusCollection collection =
+            await CreateCollectionAsync(nameof(AddCollectionField_requires_nullable_even_with_a_default_value));
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AddCollectionFieldAsync(
+                FieldSchema.Create<long>("extra", defaultValue: 99L), TestContext.Current.CancellationToken));
+
+        Assert.Contains("nullable", exception.Message);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_backfills_null_for_existing_rows()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection =
+            await CreateLoadedCollectionWithOneRowAsync(nameof(AddCollectionField_backfills_null_for_existing_rows));
+
+        await collection.AddCollectionFieldAsync(
+            FieldSchema.Create<long?>("extra", nullable: true), TestContext.Current.CancellationToken);
+
+        var field = (FieldData<long?>)await QuerySingleFieldAsync(collection, "extra");
+        Assert.Null(Assert.Single(field.Data));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_backfills_the_default_value_for_existing_and_new_rows()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateLoadedCollectionWithOneRowAsync(
+            nameof(AddCollectionField_backfills_the_default_value_for_existing_and_new_rows));
+
+        await collection.AddCollectionFieldAsync(
+            FieldSchema.Create<long?>("extra", nullable: true, defaultValue: 55L),
+            TestContext.Current.CancellationToken);
+
+        var existingRowField = (FieldData<long?>)await QuerySingleFieldAsync(collection, "extra", "id == 1");
+        Assert.Equal(55L, Assert.Single(existingRowField.Data));
+
+        // A row inserted after the field exists, which does not mention it, gets the same default --
+        // same behavior as a field declared at collection-creation time.
+        await collection.InsertAsync(
+            new FieldData[]
+            {
+                FieldData.Create("id", new[] { 2L }),
+                FieldData.CreateFloatVector("vector", new[] { new ReadOnlyMemory<float>(new[] { 0f, 1f }) })
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        var newRowField = (FieldData<long?>)await QuerySingleFieldAsync(collection, "extra", "id == 2");
+        Assert.Equal(55L, Assert.Single(newRowField.Data));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_rejects_a_vector_field()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateCollectionAsync(nameof(AddCollectionField_rejects_a_vector_field));
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AddCollectionFieldAsync(
+                FieldSchema.CreateFloatVector("extra_vector", 2), TestContext.Current.CancellationToken));
+
+        Assert.Contains("vector", exception.Message);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_rejects_a_duplicate_field_name()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection =
+            await CreateCollectionAsync(nameof(AddCollectionField_rejects_a_duplicate_field_name));
+
+        await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AddCollectionFieldAsync(
+                FieldSchema.Create<long?>("id", nullable: true), TestContext.Current.CancellationToken));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task AddCollectionField_throws_for_a_collection_that_does_not_exist()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection("schema_evolution_tests_no_such_collection");
+
+        await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.AddCollectionFieldAsync(
+                FieldSchema.Create<long?>("extra", nullable: true), TestContext.Current.CancellationToken));
+    }
+
+    private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 6);
+
+    private async Task<FieldData> QuerySingleFieldAsync(
+        MilvusCollection collection, string fieldName, string filter = "id == 1")
+    {
+        IReadOnlyList<FieldData> fields = await collection.QueryAsync(
+            filter,
+            new QueryParameters { OutputFields = { fieldName }, ConsistencyLevel = ConsistencyLevel.Strong },
+            TestContext.Current.CancellationToken);
+
+        return Assert.Single(fields, f => f.FieldName == fieldName);
+    }
+
+    private async Task<MilvusCollection> CreateCollectionAsync(string name)
+    {
+        MilvusCollection collection = Client.GetCollection(name);
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            name,
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateFloatVector("vector", 2)
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        return collection;
+    }
+
+    private async Task<MilvusCollection> CreateLoadedCollectionWithOneRowAsync(string name)
+    {
+        MilvusCollection collection = await CreateCollectionAsync(name);
+
+        await collection.CreateIndexAsync(
+            "vector", IndexType.Flat, SimilarityMetricType.L2, "vector_idx",
+            new Dictionary<string, string>(), TestContext.Current.CancellationToken);
+
+        await collection.InsertAsync(
+            new FieldData[]
+            {
+                FieldData.Create("id", new[] { 1L }),
+                FieldData.CreateFloatVector("vector", new[] { new ReadOnlyMemory<float>(new[] { 1f, 0f }) })
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(
+            waitingInterval: TimeSpan.FromMilliseconds(100), timeout: TimeSpan.FromMinutes(1),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        return collection;
+    }
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private readonly MilvusClient Client = milvusFixture.CreateClient();
+}

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -536,16 +536,16 @@ public sealed class FieldSchema
             case MilvusDataType.Int8:
             case MilvusDataType.Int16:
             case MilvusDataType.Int32:
-                valueField.IntData = (int)value;
+                valueField.IntData = Convert.ToInt32(value, CultureInfo.InvariantCulture);
                 break;
             case MilvusDataType.Int64:
-                valueField.LongData = (long)value;
+                valueField.LongData = Convert.ToInt64(value, CultureInfo.InvariantCulture);
                 break;
             case MilvusDataType.Float:
-                valueField.FloatData = (float)value;
+                valueField.FloatData = Convert.ToSingle(value, CultureInfo.InvariantCulture);
                 break;
             case MilvusDataType.Double:
-                valueField.DoubleData = (double)value;
+                valueField.DoubleData = Convert.ToDouble(value, CultureInfo.InvariantCulture);
                 break;
             case MilvusDataType.String:
             case MilvusDataType.VarChar:

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
 
 namespace Milvus.Client;
 
@@ -450,4 +452,111 @@ public sealed class FieldSchema
     public long FieldId { get; }
 
     private string DebuggerDisplay => $"{Name} ({DataType})";
+
+    /// <summary>
+    /// Converts this field schema to its wire representation. Shared by <c>CreateCollection</c>, which sends a
+    /// whole schema, and <c>AddCollectionField</c>, which sends one field's schema on its own.
+    /// </summary>
+    internal Grpc.FieldSchema ToGrpc()
+    {
+        Grpc.FieldSchema grpcField = new()
+        {
+            Name = Name,
+            DataType = (Grpc.DataType)(int)DataType,
+            ElementType = (Grpc.DataType)(int)ElementDataType,
+            IsPrimaryKey = IsPrimaryKey,
+            IsPartitionKey = IsPartitionKey,
+            AutoID = AutoId,
+            Nullable = Nullable,
+            Description = Description
+        };
+
+        if (MaxLength is not null)
+        {
+            grpcField.TypeParams.Add(new Grpc.KeyValuePair
+            {
+                Key = Constants.VarcharMaxLength,
+                Value = MaxLength.Value.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
+        if (Dimension is not null)
+        {
+            grpcField.TypeParams.Add(new Grpc.KeyValuePair
+            {
+                Key = Constants.VectorDim,
+                Value = Dimension.Value.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
+        if (MaxCapacity is not null)
+        {
+            grpcField.TypeParams.Add(new Grpc.KeyValuePair
+            {
+                Key = Constants.MaxCapacity,
+                Value = MaxCapacity.Value.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
+        if (DefaultValue is not null)
+        {
+            grpcField.DefaultValue = ConvertToValueField(DefaultValue, DataType);
+        }
+
+        if (EnableAnalyzer)
+        {
+            grpcField.TypeParams.Add(new Grpc.KeyValuePair
+            {
+                Key = Constants.EnableAnalyzer,
+                Value = "true"
+            });
+        }
+
+        if (AnalyzerParams is not null)
+        {
+            grpcField.TypeParams.Add(new Grpc.KeyValuePair
+            {
+                Key = Constants.AnalyzerParams,
+                Value = JsonSerializer.Serialize(AnalyzerParams)
+            });
+        }
+
+        return grpcField;
+    }
+
+    private static Grpc.ValueField ConvertToValueField(object value, MilvusDataType dataType)
+    {
+        Grpc.ValueField valueField = new();
+
+        switch (dataType)
+        {
+            case MilvusDataType.Bool:
+                valueField.BoolData = (bool)value;
+                break;
+            case MilvusDataType.Int8:
+            case MilvusDataType.Int16:
+            case MilvusDataType.Int32:
+                valueField.IntData = (int)value;
+                break;
+            case MilvusDataType.Int64:
+                valueField.LongData = (long)value;
+                break;
+            case MilvusDataType.Float:
+                valueField.FloatData = (float)value;
+                break;
+            case MilvusDataType.Double:
+                valueField.DoubleData = (double)value;
+                break;
+            case MilvusDataType.String:
+            case MilvusDataType.VarChar:
+                valueField.StringData = (string)value;
+                break;
+            default:
+                throw new ArgumentException(
+                    $"Default values are not supported for {dataType} fields. Only scalar fields support default values.",
+                    nameof(value));
+        }
+
+        return valueField;
+    }
 }

--- a/Milvus.Client/FunctionSchema.cs
+++ b/Milvus.Client/FunctionSchema.cs
@@ -114,4 +114,29 @@ public sealed class FunctionSchema
     public IDictionary<string, string> Params => _params;
 
     private string DebuggerDisplay => $"{Name} ({Type})";
+
+    /// <summary>
+    /// Converts this function schema to its wire representation. Shared by <c>CreateCollection</c>, which sends a
+    /// whole schema, and <c>AddCollectionFunction</c>/<c>AlterCollectionFunction</c>, which send one function's
+    /// schema on its own.
+    /// </summary>
+    internal Grpc.FunctionSchema ToGrpc()
+    {
+        Grpc.FunctionSchema grpcFunction = new()
+        {
+            Name = Name,
+            Description = Description,
+            Type = (Grpc.FunctionType)(int)Type
+        };
+
+        grpcFunction.InputFieldNames.AddRange(InputFieldNames);
+        grpcFunction.OutputFieldNames.AddRange(OutputFieldNames);
+
+        foreach (KeyValuePair<string, string> param in Params)
+        {
+            grpcFunction.Params.Add(new Grpc.KeyValuePair { Key = param.Key, Value = param.Value });
+        }
+
+        return grpcFunction;
+    }
 }

--- a/Milvus.Client/MilvusClient.Collection.cs
+++ b/Milvus.Client/MilvusClient.Collection.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using System.Text.Json;
-
-namespace Milvus.Client;
+﻿namespace Milvus.Client;
 
 public partial class MilvusClient
 {
@@ -84,93 +81,12 @@ public partial class MilvusClient
 
         foreach (FieldSchema field in schema.Fields)
         {
-            Grpc.FieldSchema grpcField = new()
-            {
-                Name = field.Name,
-                DataType = (DataType)(int)field.DataType,
-                ElementType = (DataType)(int)field.ElementDataType,
-                IsPrimaryKey = field.IsPrimaryKey,
-                IsPartitionKey = field.IsPartitionKey,
-                AutoID = field.AutoId,
-                Nullable = field.Nullable,
-                Description = field.Description
-            };
-
-            if (field.MaxLength is not null)
-            {
-                grpcField.TypeParams.Add(new Grpc.KeyValuePair
-                {
-                    Key = Constants.VarcharMaxLength,
-                    Value = field.MaxLength.Value.ToString(CultureInfo.InvariantCulture)
-                });
-            }
-
-            if (field.Dimension is not null)
-            {
-                grpcField.TypeParams.Add(new Grpc.KeyValuePair
-                {
-                    Key = Constants.VectorDim,
-                    Value = field.Dimension.Value.ToString(CultureInfo.InvariantCulture)
-                });
-            }
-
-            if (field.MaxCapacity is not null)
-            {
-                grpcField.TypeParams.Add(new Grpc.KeyValuePair
-                {
-                    Key = Constants.MaxCapacity,
-                    Value = field.MaxCapacity.Value.ToString(CultureInfo.InvariantCulture)
-                });
-            }
-
-            if (field.DefaultValue is not null)
-            {
-                grpcField.DefaultValue = ConvertToValueField(field.DefaultValue, field.DataType);
-            }
-
-            if (field.EnableAnalyzer)
-            {
-                grpcField.TypeParams.Add(new Grpc.KeyValuePair
-                {
-                    Key = Constants.EnableAnalyzer,
-                    Value = "true"
-                });
-            }
-
-            if (field.AnalyzerParams is not null)
-            {
-                grpcField.TypeParams.Add(new Grpc.KeyValuePair
-                {
-                    Key = Constants.AnalyzerParams,
-                    Value = JsonSerializer.Serialize(field.AnalyzerParams)
-                });
-            }
-
-            grpcCollectionSchema.Fields.Add(grpcField);
+            grpcCollectionSchema.Fields.Add(field.ToGrpc());
         }
 
         foreach (FunctionSchema function in schema.Functions)
         {
-            Grpc.FunctionSchema grpcFunction = new()
-            {
-                Name = function.Name,
-                Description = function.Description,
-                Type = (Grpc.FunctionType)(int)function.Type
-            };
-
-            grpcFunction.InputFieldNames.AddRange(function.InputFieldNames);
-            grpcFunction.OutputFieldNames.AddRange(function.OutputFieldNames);
-
-            foreach (var param in function.Params)
-            {
-                grpcFunction.Params.Add(new Grpc.KeyValuePair
-                {
-                    Key = param.Key,
-                    Value = param.Value
-                });
-            }
-
-            grpcCollectionSchema.Functions.Add(grpcFunction);
+            grpcCollectionSchema.Functions.Add(function.ToGrpc());
         }
 
 #pragma warning disable CS0612 // Schema-level AutoID is obsolete, but still there in pymilvus
@@ -290,41 +206,5 @@ public partial class MilvusClient
                 .ConfigureAwait(false);
 
         return FlushResult.From(response);
-    }
-
-    private static Grpc.ValueField ConvertToValueField(object value, MilvusDataType dataType)
-    {
-        Grpc.ValueField valueField = new();
-
-        switch (dataType)
-        {
-            case MilvusDataType.Bool:
-                valueField.BoolData = (bool)value;
-                break;
-            case MilvusDataType.Int8:
-            case MilvusDataType.Int16:
-            case MilvusDataType.Int32:
-                valueField.IntData = (int)value;
-                break;
-            case MilvusDataType.Int64:
-                valueField.LongData = (long)value;
-                break;
-            case MilvusDataType.Float:
-                valueField.FloatData = (float)value;
-                break;
-            case MilvusDataType.Double:
-                valueField.DoubleData = (double)value;
-                break;
-            case MilvusDataType.String:
-            case MilvusDataType.VarChar:
-                valueField.StringData = (string)value;
-                break;
-            default:
-                throw new ArgumentException(
-                    $"Default values are not supported for {dataType} fields. Only scalar fields support default values.",
-                    nameof(value));
-        }
-
-        return valueField;
     }
 }

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -221,6 +221,108 @@ public partial class MilvusCollection
     }
 
     /// <summary>
+    /// Adds a function to an existing collection. Available since Milvus v2.6.
+    /// </summary>
+    /// <param name="function">
+    /// The function to add. Its input and output fields must already exist in the collection -- this
+    /// does not create them.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <exception cref="MilvusException">
+    /// Always, for a <see cref="FunctionType.Bm25" /> function as of Milvus 2.6.20 -- see the remarks.
+    /// Also thrown for an input or output field that does not exist.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// <b>Not currently usable for BM25, the only function type this SDK can build.</b> Verified against
+    /// two server versions: Milvus 2.6.4 does not implement this RPC at all (the call fails at the gRPC
+    /// transport level with an <c>Unimplemented</c> status, surfacing as a raw
+    /// <see cref="global::Grpc.Core.RpcException" /> rather than a <see cref="MilvusException" />).
+    /// Milvus 2.6.20 does implement the RPC, but rejects a BM25 function outright with <c>"currently
+    /// does not support adding BM25 function"</c>. <see cref="FunctionType.Rerank" /> and
+    /// <see cref="FunctionType.TextEmbedding" /> are unverified -- this SDK has no builder for either,
+    /// see <see cref="FunctionSchema" />'s constructor -- so whether they fare any better is unknown.
+    /// </para>
+    /// <para>
+    /// Because <see cref="AddCollectionFieldAsync" /> refuses vector fields, a function's output field
+    /// -- typically a sparse vector for BM25 -- has to already be part of the collection's original
+    /// schema for this to have anything to attach to, once it does become usable. Until then, that
+    /// field behaves as an ordinary column: it must be supplied on every insert, exactly like any other
+    /// non-nullable field.
+    /// </para>
+    /// </remarks>
+    public async Task AddCollectionFunctionAsync(FunctionSchema function, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(function);
+
+        var request = new AddCollectionFunctionRequest { CollectionName = Name, FunctionSchema = function.ToGrpc() };
+
+        await _client.InvokeAsync(_client.GrpcClient.AddCollectionFunctionAsync, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Replaces the definition of an existing function. Available since Milvus v2.6.
+    /// </summary>
+    /// <param name="functionName">The name of the function to alter.</param>
+    /// <param name="newFunction">The function's new definition, which replaces the old one entirely.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <exception cref="MilvusException">
+    /// Always, for a <see cref="FunctionType.Bm25" /> function as of Milvus 2.6.20: rejected with
+    /// <c>"currently does not support alter BM25 function"</c>, the same restriction documented on
+    /// <see cref="AddCollectionFunctionAsync" />. Also thrown when <paramref name="functionName" />
+    /// does not exist.
+    /// </exception>
+    public async Task AlterCollectionFunctionAsync(
+        string functionName, FunctionSchema newFunction, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(functionName);
+        Verify.NotNull(newFunction);
+
+        var request = new AlterCollectionFunctionRequest
+        {
+            CollectionName = Name,
+            FunctionName = functionName,
+            FunctionSchema = newFunction.ToGrpc()
+        };
+
+        await _client.InvokeAsync(_client.GrpcClient.AlterCollectionFunctionAsync, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Drops a function from a collection. Available since Milvus v2.6.
+    /// </summary>
+    /// <param name="functionName">The name of the function to drop.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Dropping a function that does not exist was observed to succeed silently on Milvus 2.6.20
+    /// rather than throw -- confirmed both for a function name that was never valid, and for one whose
+    /// add had itself failed (see <see cref="AddCollectionFunctionAsync" />). Whether this holds for a
+    /// function that genuinely existed and was actively producing output could not be verified: adding
+    /// a function currently fails for every function type this SDK can construct, so there was nothing
+    /// real to drop. On Milvus 2.6.4 this RPC is not implemented at all, the same as
+    /// <see cref="AddCollectionFunctionAsync" /> and <see cref="AlterCollectionFunctionAsync" />.
+    /// </para>
+    /// </remarks>
+    public async Task DropCollectionFunctionAsync(string functionName, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(functionName);
+
+        var request = new DropCollectionFunctionRequest { CollectionName = Name, FunctionName = functionName };
+
+        await _client.InvokeAsync(_client.GrpcClient.DropCollectionFunctionAsync, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Renames a collection.
     /// </summary>
     /// <param name="newName">The new collection name.</param>

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -140,8 +140,9 @@ public partial class MilvusCollection
     /// applies to new rows that omit the field going forward, same as at collection creation.
     /// </para>
     /// <para>
-    /// The collection does not need to be released first, but a newly added field is not searchable or
-    /// queryable in already-loaded segments until the collection is released and reloaded.
+    /// The collection does not need to be released first, and — verified against Milvus 2.6.4 — a newly
+    /// added field is immediately queryable on an already-loaded collection, with no release/reload
+    /// required.
     /// </para>
     /// </remarks>
     public async Task AddCollectionFieldAsync(FieldSchema field, CancellationToken cancellationToken = default)

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -117,6 +117,48 @@ public partial class MilvusCollection
     }
 
     /// <summary>
+    /// Adds a new field to an existing collection. Available since Milvus v2.6.
+    /// </summary>
+    /// <param name="field">
+    /// The field to add. Must have <see cref="FieldSchema.Nullable" /> set — Milvus rejects any added
+    /// field that isn't, even an empty collection with no existing rows to reconcile, and even one
+    /// that also sets <see cref="FieldSchema.DefaultValue" />: a default does not substitute for
+    /// nullable, the two are independent requirements. Vector fields cannot be added this way.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <exception cref="MilvusException">
+    /// <paramref name="field" /> is not nullable, is a vector type, or duplicates an existing field
+    /// name; or the collection does not exist.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Rows that existed before the field was added read back as <see langword="null" /> for it,
+    /// unless <see cref="FieldSchema.DefaultValue" /> is also set, in which case they read back as
+    /// that default — Milvus backfills it rather than leaving existing rows null. The same default
+    /// applies to new rows that omit the field going forward, same as at collection creation.
+    /// </para>
+    /// <para>
+    /// The collection does not need to be released first, but a newly added field is not searchable or
+    /// queryable in already-loaded segments until the collection is released and reloaded.
+    /// </para>
+    /// </remarks>
+    public async Task AddCollectionFieldAsync(FieldSchema field, CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(field);
+
+        var request = new AddCollectionFieldRequest
+        {
+            CollectionName = Name,
+            Schema = field.ToGrpc().ToByteString()
+        };
+
+        await _client.InvokeAsync(_client.GrpcClient.AddCollectionFieldAsync, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Renames a collection.
     /// </summary>
     /// <param name="newName">The new collection name.</param>

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -159,6 +159,68 @@ public partial class MilvusCollection
     }
 
     /// <summary>
+    /// Sets or removes properties on an existing field. Available since Milvus v2.6.
+    /// </summary>
+    /// <param name="fieldName">The name of the field to alter.</param>
+    /// <param name="properties">
+    /// Properties to set, e.g. <c>max_length</c> on a <c>VarChar</c> field, or <c>mmap.enabled</c> on
+    /// any field. At least one of <paramref name="properties" /> or <paramref name="deleteKeys" /> must
+    /// be non-empty.
+    /// </param>
+    /// <param name="deleteKeys">
+    /// Property keys to remove. Milvus only accepts a fixed set of recognized property names here --
+    /// unrecognized keys are rejected even if never set on this field, so this is not a general-purpose
+    /// key removal.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Both <paramref name="properties" /> and <paramref name="deleteKeys" /> are empty.
+    /// </exception>
+    /// <exception cref="MilvusException">
+    /// <paramref name="fieldName" /> does not exist, or a key in <paramref name="deleteKeys" /> is not
+    /// one Milvus recognizes as a field property.
+    /// </exception>
+    /// <remarks>
+    /// Unlike a typical database, <c>max_length</c> can be both increased and decreased freely --
+    /// confirmed empirically against 2.6.4, on both an empty field and one already holding data longer
+    /// than the new limit.
+    /// </remarks>
+    public async Task AlterCollectionFieldAsync(
+        string fieldName,
+        IReadOnlyDictionary<string, string>? properties = null,
+        IReadOnlyList<string>? deleteKeys = null,
+        CancellationToken cancellationToken = default)
+    {
+        Verify.NotNullOrWhiteSpace(fieldName);
+
+        if ((properties is null || properties.Count == 0) && (deleteKeys is null || deleteKeys.Count == 0))
+        {
+            throw new ArgumentException(
+                $"At least one of {nameof(properties)} or {nameof(deleteKeys)} must be non-empty.");
+        }
+
+        var request = new AlterCollectionFieldRequest { CollectionName = Name, FieldName = fieldName };
+
+        if (properties is not null)
+        {
+            foreach (KeyValuePair<string, string> property in properties)
+            {
+                request.Properties.Add(new Grpc.KeyValuePair { Key = property.Key, Value = property.Value });
+            }
+        }
+
+        if (deleteKeys is not null)
+        {
+            request.DeleteKeys.AddRange(deleteKeys);
+        }
+
+        await _client.InvokeAsync(_client.GrpcClient.AlterCollectionFieldAsync, request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Renames a collection.
     /// </summary>
     /// <param name="newName">The new collection name.</param>


### PR DESCRIPTION
Implements 2.6's schema-evolution surface (`AddCollectionField`, `AlterCollectionField`, `Add/Alter/DropCollectionFunction`). 4 commits, each with tests, all verified against the full CI matrix (v2.3.22 / v2.4.23 / v2.5.20 / v2.6.4) at **258 passed / 1 skipped / 0 failed** per version.

## What works

**`AddCollectionFieldAsync`** — adds a field to an existing collection.
- Milvus requires the added field to be `Nullable`, unconditionally. A `DefaultValue` does **not** substitute for it — setting both is required to get non-null backfill; setting only `DefaultValue` is rejected the same way as setting neither.
- Existing rows backfill to the default value when one is given, otherwise `null`. New rows that omit the field afterward get the same default, same as at collection creation.
- Vector fields are rejected outright (`"not support to add vector field"`).

**`AlterCollectionFieldAsync`** — sets/removes field properties (e.g. `mmap.enabled`, `max_length`).
- `max_length` can be freely **increased or decreased**, even below the length of data already stored — confirmed by shrinking to 5 after inserting an 18-character string and reading it back unchanged. Not a retroactive constraint.
- `deleteKeys` rejects a key **by name**, not by whether it was ever set — a made-up key is rejected even though it was never set on anything, while a real key like `mmap.enabled` deletes cleanly even when never set. It's a recognized-property allow-list, not idempotent removal.
- Client-side guard requires at least one of `properties`/`deleteKeys` to be non-empty, matching the server's own validation but failing fast.

## What's implemented but not currently usable

**`Add/Alter/DropCollectionFunctionAsync`** — the wire code is correct (reuses `FunctionSchema.ToGrpc()`, same pattern as the field methods), but none of the three succeeds today for **BM25**, the only function type this SDK can build (`FunctionSchema.CreateBm25` is the sole builder; `Rerank`/`TextEmbedding` are enum-only from #134, unwired).

Tested against two server versions:
- **2.6.4**: the RPCs don't exist at the gRPC level at all — the call fails with `Unimplemented` at the transport layer, surfacing as a raw `RpcException` rather than a `MilvusException`.
- **2.6.20** (latest GA): the RPCs exist, but `Add`/`Alter` explicitly reject BM25 (`"currently does not support adding/alter BM25 function"`). `Drop` on a not-found function succeeds silently.

Rather than leave this untested or stub it out, the tests assert the *current* rejection while failing loudly if it ever starts succeeding:

```csharp
catch (RpcException e) when (e.StatusCode == StatusCode.Unimplemented) { }   // 2.6.4
catch (MilvusException e) { Assert.Contains("BM25", e.Message); }            // 2.6.20
// falls through to Assert.Fail(...) if it ever just succeeds
```

That gives permanent regression coverage instead of either an untestable stub or silently skipped code, and will fail the moment Milvus lifts the restriction.

## Refactor

Extracted `FieldSchema.ToGrpc()` / `FunctionSchema.ToGrpc()` out of `CreateCollectionAsync`, which previously built the same conversion inline for a whole schema. No behavior change — verified against `CollectionTests`, `FieldTests` and `Bm25Tests`. Needed so `AddCollectionField`/`AddCollectionFunction` could send one field/function without duplicating that ~90-line conversion.
