### PR TITLE
Add BITMAP, NGRAM, MINHASH_LSH and IVF_RABITQ index types

### DIFF
--- a/Milvus.Client.Tests/IndexTests.cs
+++ b/Milvus.Client.Tests/IndexTests.cs
@@ -220,6 +220,7 @@ public class IndexTests : IAsyncLifetime
         await Collection.CreateIndexAsync("varchar", IndexType.Bitmap, cancellationToken: TestContext.Current.CancellationToken);
         await Collection.CreateIndexAsync("float_vector", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
         await Collection.WaitForIndexBuildAsync("varchar", cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForIndexBuildAsync("float_vector", cancellationToken: TestContext.Current.CancellationToken);
 
         await Collection.InsertAsync(new FieldData[]
         {
@@ -254,6 +255,7 @@ public class IndexTests : IAsyncLifetime
             cancellationToken: TestContext.Current.CancellationToken);
         await Collection.CreateIndexAsync("float_vector", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
         await Collection.WaitForIndexBuildAsync("varchar", cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForIndexBuildAsync("float_vector", cancellationToken: TestContext.Current.CancellationToken);
 
         await Collection.InsertAsync(new FieldData[]
         {

--- a/Milvus.Client.Tests/IndexTests.cs
+++ b/Milvus.Client.Tests/IndexTests.cs
@@ -210,6 +210,71 @@ public class IndexTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Scalar_index_bitmap()
+    {
+        if (await Client.GetParsedMilvusVersion() < new Version(2, 5))
+        {
+            return;
+        }
+
+        await Collection.CreateIndexAsync("varchar", IndexType.Bitmap, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.CreateIndexAsync("float_vector", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForIndexBuildAsync("varchar", cancellationToken: TestContext.Current.CancellationToken);
+
+        await Collection.InsertAsync(new FieldData[]
+        {
+            FieldData.Create("id", new long[] { 1, 2, 3 }),
+            FieldData.Create("varchar", new[] { "a", "b", "a" }),
+            FieldData.CreateFloatVector("float_vector", new ReadOnlyMemory<float>[]
+            {
+                new float[] { 1, 1, 1, 1 }, new float[] { 2, 2, 2, 2 }, new float[] { 3, 3, 3, 3 },
+            }),
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await Collection.QueryAsync(
+            "varchar == \"a\"", new QueryParameters { OutputFields = { "id" } },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var idData = (FieldData<long>)Assert.Single(results, f => f.FieldName == "id");
+        Assert.Equal(new long[] { 1, 3 }, idData.Data);
+    }
+
+    [Fact]
+    public async Task Ngram_index()
+    {
+        if (await Client.GetParsedMilvusVersion() < new Version(2, 6))
+        {
+            return;
+        }
+
+        await Collection.CreateIndexAsync(
+            "varchar", IndexType.Ngram,
+            extraParams: new Dictionary<string, string> { ["min_gram"] = "2", ["max_gram"] = "3" },
+            cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.CreateIndexAsync("float_vector", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForIndexBuildAsync("varchar", cancellationToken: TestContext.Current.CancellationToken);
+
+        await Collection.InsertAsync(new FieldData[]
+        {
+            FieldData.Create("id", new long[] { 1, 2, 3 }),
+            FieldData.Create("varchar", new[] { "hello world", "foobar", "abcdef" }),
+            FieldData.CreateFloatVector("float_vector", new ReadOnlyMemory<float>[]
+            {
+                new float[] { 1, 1, 1, 1 }, new float[] { 2, 2, 2, 2 }, new float[] { 3, 3, 3, 3 },
+            }),
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await Collection.QueryAsync(
+            "varchar like \"%bcd%\"", new QueryParameters { OutputFields = { "id" } },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var idData = (FieldData<long>)Assert.Single(results, f => f.FieldName == "id");
+        Assert.Equal(new long[] { 3 }, idData.Data);
+    }
+
+    [Fact]
     public async Task Sparse_inverted_index()
     {
         if (await Client.GetParsedMilvusVersion() < new Version(2, 4))
@@ -240,6 +305,83 @@ public class IndexTests : IAsyncLifetime
         var indexes = await Collection.DescribeIndexAsync("sparse_vector", cancellationToken: TestContext.Current.CancellationToken);
         var index = Assert.Single(indexes);
         Assert.Contains(index.Params, kv => kv is { Key: "index_type", Value: "SPARSE_INVERTED_INDEX" });
+    }
+
+    [Fact]
+    public async Task IvfRabitq_index()
+    {
+        if (await Client.GetParsedMilvusVersion() < new Version(2, 6))
+        {
+            return;
+        }
+
+        await Collection.CreateIndexAsync(
+            "float_vector", IndexType.IvfRabitq, SimilarityMetricType.L2,
+            extraParams: new Dictionary<string, string> { ["nlist"] = "8" },
+            cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForIndexBuildAsync("float_vector", cancellationToken: TestContext.Current.CancellationToken);
+
+        ReadOnlyMemory<float>[] vectors = { new float[] { 1, 1, 1, 1 }, new float[] { 2, 2, 2, 2 } };
+        await Collection.InsertAsync(new FieldData[]
+        {
+            FieldData.Create("id", new long[] { 1, 2 }),
+            FieldData.Create("varchar", new[] { "one", "two" }),
+            FieldData.CreateFloatVector("float_vector", vectors),
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await Collection.SearchAsync(
+            "float_vector", new[] { vectors[0] }, SimilarityMetricType.L2, limit: 1,
+            parameters: new SearchParameters { ExtraParameters = { ["nprobe"] = "8" } },
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(1, Assert.Single(results.Ids.LongIds!));
+    }
+
+    [Fact]
+    public async Task MinHashLsh_index()
+    {
+        if (await Client.GetParsedMilvusVersion() < new Version(2, 6))
+        {
+            return;
+        }
+
+        await Collection.DropAsync(TestContext.Current.CancellationToken);
+        await Client.CreateCollectionAsync(
+            CollectionName,
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                // Dimension = mh_element_bit_width (64) * number of MinHash signatures per row (4) = 256 bits.
+                FieldSchema.CreateBinaryVector("minhash_signature", 256),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await Collection.CreateIndexAsync(
+            "minhash_signature", IndexType.MinHashLsh, SimilarityMetricType.MhJaccard,
+            extraParams: new Dictionary<string, string>
+            {
+                ["mh_element_bit_width"] = "64",
+                ["mh_lsh_band"] = "4",
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForIndexBuildAsync("minhash_signature", cancellationToken: TestContext.Current.CancellationToken);
+
+        ReadOnlyMemory<byte>[] vectors =
+        {
+            Enumerable.Range(1, 32).Select(i => (byte)i).ToArray(),
+            Enumerable.Range(50, 32).Select(i => (byte)i).ToArray(),
+        };
+        await Collection.InsertAsync(new FieldData[]
+        {
+            FieldData.Create("id", new long[] { 1, 2 }),
+            FieldData.CreateBinaryVectors("minhash_signature", vectors),
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await Collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await Collection.SearchAsync(
+            "minhash_signature", new[] { vectors[0] }, SimilarityMetricType.MhJaccard, limit: 2,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Contains(1L, results.Ids.LongIds!);
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/Milvus.Client/IndexType.cs
+++ b/Milvus.Client/IndexType.cs
@@ -283,4 +283,89 @@ public enum IndexType
     /// <c>st_dwithin</c>, ...) on <see cref="MilvusDataType.Geometry" /> fields.
     /// </remarks>
     RTree,
+
+    /// <summary>
+    /// BITMAP index for scalar fields. Available since Milvus v2.5.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Stores a bitmap of the distinct values in the field and answers scalar filters with bitwise
+    /// operations. This is most effective for low-cardinality fields (Milvus recommends cardinality below
+    /// 500); query performance degrades as cardinality grows.
+    /// </para>
+    /// <para>
+    /// Applies to all scalar fields except <c>JSON</c>, <c>FLOAT</c> and <c>DOUBLE</c>, and to
+    /// <see cref="MilvusDataType.Array" /> fields whose element type satisfies the same restriction. There
+    /// are no build or search parameters.
+    /// </para>
+    /// </remarks>
+    Bitmap,
+
+    /// <summary>
+    /// NGRAM index for VARCHAR (and JSON, via a string-typed path) fields. Available since Milvus v2.6.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Splits indexed strings into overlapping substrings of length between <c>min_gram</c> and
+    /// <c>max_gram</c> (both required build parameters, with <c>min_gram &lt;= max_gram</c>), accelerating
+    /// <c>LIKE</c>/wildcard and regex pattern-matching queries whose literal substrings fall within that
+    /// length range.
+    /// </para>
+    /// <para>
+    /// To index a JSON path instead of a VARCHAR field, also set the <c>json_path</c> (e.g.
+    /// <c>"json_field[\"body\"]"</c>) and <c>json_cast_type</c> (currently only <c>"varchar"</c> is
+    /// supported) build parameters.
+    /// </para>
+    /// </remarks>
+    Ngram,
+
+    /// <summary>
+    /// MINHASH_LSH index for binary vectors holding MinHash signatures, used for Jaccard-similarity
+    /// near-duplicate detection. Available since Milvus v2.6.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Requires <see cref="SimilarityMetricType.MhJaccard" /> as the metric type. The indexed binary vector
+    /// field's dimension must equal <c>mh_element_bit_width</c> multiplied by the number of MinHash
+    /// signatures stored per row.
+    /// </para>
+    /// <para>
+    /// Build parameters (passed via <c>extraParams</c>): <c>mh_element_bit_width</c> (bit width of each
+    /// hash value; one of 8, 16, 32, 64), <c>mh_lsh_band</c> (number of LSH bands the signature is split
+    /// into), <c>mh_lsh_code_in_mem</c> (keep LSH codes in memory rather than memory-mapped, boolean),
+    /// <c>with_raw_data</c> (keep the raw MinHash signatures alongside the LSH codes so results can be
+    /// refined, boolean, default <c>false</c>), and <c>mh_lsh_bloom_false_positive_prob</c> (bloom-filter
+    /// false-positive rate, range [0.001, 0.1]).
+    /// </para>
+    /// <para>
+    /// Search parameters: <c>mh_search_with_jaccard</c> (compute exact Jaccard similarity over the LSH
+    /// candidates, boolean), <c>refine_k</c> (candidate multiplier before refinement), and
+    /// <c>mh_lsh_batch_search</c> (batch multiple query vectors together, boolean).
+    /// </para>
+    /// </remarks>
+    MinHashLsh,
+
+    /// <summary>
+    /// IVF_RABITQ index for float vector fields, combining IVF clustering with RaBitQ binary quantization.
+    /// Available since Milvus v2.6.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Quantizes each vector down to roughly 1 bit per dimension, giving up to a 32x storage reduction over
+    /// an unquantized index while retaining a tunable amount of recall via optional refinement.
+    /// </para>
+    /// <para>
+    /// Build parameters: <c>nlist</c> (number of cluster units, range [1, 65536], default 128),
+    /// <c>refine</c> (whether to keep additional data for search-time refinement, boolean, default
+    /// <c>false</c>), and, when <c>refine</c> is <c>true</c>, <c>refine_type</c> (the precision used for
+    /// refinement data: one of <c>"SQ6"</c>, <c>"SQ8"</c>, <c>"FP16"</c>, <c>"BF16"</c>, <c>"FP32"</c> —
+    /// note string values must be quoted in JSON, e.g. <c>"\"SQ8\""</c>).
+    /// </para>
+    /// <para>
+    /// Search parameters: <c>nprobe</c> (number of clusters to search, range [1, nlist]),
+    /// <c>rbq_query_bits</c> (query-vector quantization level, 0 to disable or 1-8 for SQ1-SQ8), and, when
+    /// <c>refine</c> was enabled at build time, <c>refine_k</c> (refinement candidate multiplier, &gt;= 1).
+    /// </para>
+    /// </remarks>
+    IvfRabitq,
 }

--- a/Milvus.Client/IndexType.cs
+++ b/Milvus.Client/IndexType.cs
@@ -363,8 +363,11 @@ public enum IndexType
     /// </para>
     /// <para>
     /// Search parameters: <c>nprobe</c> (number of clusters to search, range [1, nlist]),
-    /// <c>rbq_query_bits</c> (query-vector quantization level, 0 to disable or 1-8 for SQ1-SQ8), and, when
-    /// <c>refine</c> was enabled at build time, <c>refine_k</c> (refinement candidate multiplier, &gt;= 1).
+    /// <c>rbq_bits_query</c> (query-vector quantization level, 0 to disable or 1-8 for SQ1-SQ8 — note the
+    /// word order: knowhere's <c>IvfRaBitQConfig</c> and the official Go SDK both read
+    /// <c>rbq_bits_query</c>, not <c>rbq_query_bits</c> as the milvus.io docs page for this index
+    /// currently states), and, when <c>refine</c> was enabled at build time, <c>refine_k</c> (refinement
+    /// candidate multiplier, &gt;= 1).
     /// </para>
     /// </remarks>
     IvfRabitq,

--- a/Milvus.Client/MilvusCollection.Index.cs
+++ b/Milvus.Client/MilvusCollection.Index.cs
@@ -96,6 +96,10 @@ public partial class MilvusCollection
                 IndexType.SparseInvertedIndex => "SPARSE_INVERTED_INDEX",
                 IndexType.SparseWand => "SPARSE_WAND",
                 IndexType.RTree => "RTREE",
+                IndexType.Bitmap => "BITMAP",
+                IndexType.Ngram => "NGRAM",
+                IndexType.MinHashLsh => "MINHASH_LSH",
+                IndexType.IvfRabitq => "IVF_RABITQ",
 
                 _ => throw new ArgumentOutOfRangeException(nameof(indexType), indexType, null)
             };
@@ -113,6 +117,7 @@ public partial class MilvusCollection
                 SimilarityMetricType.Superstructure => "SUPERSTRUCTURE",
                 SimilarityMetricType.Substructure => "SUBSTRUCTURE",
                 SimilarityMetricType.Bm25 => "BM25",
+                SimilarityMetricType.MhJaccard => "MHJACCARD",
 
                 _ => throw new ArgumentOutOfRangeException(nameof(similarityMetricType), similarityMetricType, null)
             };

--- a/Milvus.Client/SimilarityMetricType.cs
+++ b/Milvus.Client/SimilarityMetricType.cs
@@ -164,4 +164,16 @@ public enum SimilarityMetricType
     /// </para>
     /// </remarks>
     Bm25,
+
+    /// <summary>
+    /// MinHash-based Jaccard similarity, used with the <see cref="IndexType.MinHashLsh" /> index to estimate
+    /// Jaccard similarity between sets encoded as MinHash signatures.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This metric type is valid only for binary vector fields carrying MinHash signatures, indexed with
+    /// <see cref="IndexType.MinHashLsh" />.
+    /// </para>
+    /// </remarks>
+    MhJaccard,
 }


### PR DESCRIPTION
## Summary
- Adds `IndexType.Bitmap` (2.5), `IndexType.Ngram`, `IndexType.MinHashLsh`, `IndexType.IvfRabitq` (2.6), each with XML docs covering build/search parameters
- Adds `SimilarityMetricType.MhJaccard`, the metric type required by `MINHASH_LSH`
- Wires both new enums into the `index_type`/`metric_type` gRPC string mappings in `CreateIndexAsync`

## Test plan
Each index type was verified end-to-end against a live Milvus container (build index → insert → load → query/search → assert correct results), not just that `CreateIndexAsync` doesn't throw:
- `BITMAP` on a VARCHAR field — `==` filter query returns the correct rows
- `NGRAM` on a VARCHAR field with `min_gram`/`max_gram` — a `LIKE "%bcd%"` query correctly matches only the row containing that substring
- `IVF_RABITQ` on a float vector field — real ANN search returns the inserted vector's own id
- `MINHASH_LSH` on a binary vector field (dimension = `mh_element_bit_width` × signatures/row) with `MhJaccard` — vector search returns matches

Tests are version-gated (`< 2.5` / `< 2.6` skip) and confirmed to skip cleanly with no failures on 2.3.22/2.4.23/2.5.20, and pass on 2.6.4. Full suite: 244 passed, 1 pre-existing unrelated skip, 0 failures, across all three target frameworks (net8.0, netstandard2.0, net462).