### PR TITLE
Add Text data type, TEXT_MATCH support, RunAnalyzer, and row-based query/search results

### DIFF
--- a/Milvus.Client.Tests/IsolatedMilvusFixture.cs
+++ b/Milvus.Client.Tests/IsolatedMilvusFixture.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+using Testcontainers.Milvus;
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+/// <summary>
+/// A dedicated Milvus container, entirely separate from <see cref="MilvusFixture" />'s assembly-wide
+/// shared one. For tests whose failure mode can crash the server process itself (not just fail the
+/// one request) -- those must never run against the container every other test also depends on.
+/// Pair with <c>IClassFixture&lt;IsolatedMilvusFixture&gt;</c> on the one test class that needs it; the
+/// cost is a fresh container start (tens of seconds) for that class alone, not shared with anything else.
+/// </summary>
+/// <remarks>
+/// If the caller's test only applies from some minimum Milvus version onward (the common pattern
+/// elsewhere in this suite: check <c>GetParsedMilvusVersion()</c> and return early), check
+/// <see cref="IsAvailable" /> for the same purpose <em>before</em> calling <see cref="CreateClient" /> --
+/// it's parsed from the <c>MILVUS_IMAGE</c> tag alone, with no container involved, so a version-gated
+/// test on an older CI image never pays this fixture's container-start cost just to immediately return.
+/// </remarks>
+public sealed class IsolatedMilvusFixture : IAsyncLifetime
+{
+    private const string DefaultMilvusImage = "milvusdb/milvus:v2.6.4";
+
+    private readonly MilvusContainer? _container;
+
+    public IsolatedMilvusFixture()
+    {
+        string image = Environment.GetEnvironmentVariable("MILVUS_IMAGE") ?? DefaultMilvusImage;
+        ParsedImageVersion = ParseImageVersion(image);
+
+        // Only build (not start -- that's still InitializeAsync's job) the container when the image
+        // actually looks new enough to be worth it. An unparseable tag is treated as available rather
+        // than silently skipped, so a genuinely new/unexpected image format still gets exercised.
+        if (ParsedImageVersion is null || ParsedImageVersion >= MinimumVersion)
+        {
+            _container = new MilvusBuilder(image)
+                .WithEnvironment("QUOTA_AND_LIMITS_FLUSH_RATE_COLLECTION_MAX", "-1")
+                .Build();
+        }
+    }
+
+    /// <summary>
+    /// The minimum Milvus version this fixture bothers starting a container for. Tests using this
+    /// fixture are all about behavior introduced in the 2.6 line so far; bump this if that changes.
+    /// </summary>
+    private static readonly Version MinimumVersion = new(2, 6);
+
+    /// <summary>
+    /// The Milvus version parsed from the <c>MILVUS_IMAGE</c> tag (e.g. <c>v2.6.4</c> -&gt;
+    /// <c>2.6.4</c>), or <see langword="null" /> if the tag doesn't look like a version at all.
+    /// </summary>
+    public Version? ParsedImageVersion { get; }
+
+    /// <summary>
+    /// Whether this fixture actually started a container. False when <see cref="ParsedImageVersion" /> is
+    /// parsed and below the version this fixture requires -- check this (or compare
+    /// <see cref="ParsedImageVersion" /> directly) before <see cref="CreateClient" /> instead of starting
+    /// a client only to immediately discard it.
+    /// </summary>
+    public bool IsAvailable => _container is not null;
+
+    public MilvusClient CreateClient()
+        => _container is not null
+            ? new MilvusClient(_container.Hostname, "root", "Milvus", _container.GetMappedPublicPort(MilvusBuilder.MilvusGrpcPort), ssl: false)
+            : throw new InvalidOperationException(
+                $"No container was started for this fixture (MILVUS_IMAGE parsed as {ParsedImageVersion?.ToString() ?? "unparseable"}, " +
+                $"below the {MinimumVersion} this fixture requires) -- check {nameof(IsAvailable)} first.");
+
+    public ValueTask InitializeAsync() => _container is null ? default : new ValueTask(_container.StartAsync());
+    public ValueTask DisposeAsync() => _container is null ? default : _container.DisposeAsync();
+
+    private static Version? ParseImageVersion(string image)
+    {
+        // e.g. "milvusdb/milvus:v2.6.4" -> "2.6.4"
+        Match match = Regex.Match(image, @":v?(?<version>\d+(\.\d+){1,3})$");
+        return match.Success && System.Version.TryParse(match.Groups["version"].Value, out Version? version)
+            ? version
+            : null;
+    }
+}

--- a/Milvus.Client.Tests/RowResultsTests.cs
+++ b/Milvus.Client.Tests/RowResultsTests.cs
@@ -1,0 +1,125 @@
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+// See TextTests's TextTestsCollection comment: Milvus 2.6.4 has proven unstable under concurrent
+// Search/Load-heavy activity from several tests at once. Kept out of the parallel pool defensively,
+// alongside TextTests/TextMatchTests/RunAnalyzerTests.
+[CollectionDefinition(nameof(RowResultsTests), DisableParallelization = true)]
+public sealed class RowResultsTestsCollection;
+
+[Collection(nameof(RowResultsTests))]
+public class RowResultsTests(SearchQueryTests.QueryCollectionFixture queryCollectionFixture)
+    : IClassFixture<SearchQueryTests.QueryCollectionFixture>
+{
+    private MilvusCollection Collection => queryCollectionFixture.Collection;
+
+    [Fact]
+    public async Task QueryRowsAsync_returns_one_dictionary_per_row()
+    {
+        var rows = await Collection.QueryRowsAsync(
+            "id in [2, 3]",
+            new QueryParameters { OutputFields = { "varchar", "float_vector" }, ConsistencyLevel = ConsistencyLevel.Strong },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, rows.Count);
+
+        var row2 = Assert.Single(rows, r => (long)r["id"]! == 2);
+        Assert.Equal("two", row2["varchar"]);
+        Assert.Equal(3.5f, ((ReadOnlyMemory<float>)row2["float_vector"]!).Span[0]);
+
+        var row3 = Assert.Single(rows, r => (long)r["id"]! == 3);
+        Assert.Equal("three", row3["varchar"]);
+    }
+
+    [Fact]
+    public async Task QueryRowsAsync_matches_column_oriented_QueryAsync()
+    {
+        QueryParameters parameters = new() { OutputFields = { "varchar" }, ConsistencyLevel = ConsistencyLevel.Strong };
+
+        var rows = await Collection.QueryRowsAsync("id in [1, 4]", parameters, TestContext.Current.CancellationToken);
+        var columns = await Collection.QueryAsync("id in [1, 4]", parameters, TestContext.Current.CancellationToken);
+
+        var idColumn = (FieldData<long>)Assert.Single(columns, c => c.FieldName == "id");
+        var varcharColumn = (FieldData<string?>)Assert.Single(columns, c => c.FieldName == "varchar");
+
+        Assert.Equal(idColumn.Data.Count, rows.Count);
+        for (int i = 0; i < idColumn.Data.Count; i++)
+        {
+            var row = Assert.Single(rows, r => (long)r["id"]! == idColumn.Data[i]);
+            Assert.Equal(varcharColumn.Data[i], row["varchar"]);
+        }
+    }
+
+    [Fact]
+    public async Task SearchResults_GetHits_combines_id_score_and_fields()
+    {
+        SearchResults results = await Collection.SearchAsync(
+            "float_vector",
+            new ReadOnlyMemory<float>[] { new[] { 3.5f, 4.5f } },
+            SimilarityMetricType.L2,
+            limit: 2,
+            parameters: new SearchParameters { OutputFields = { "varchar" }, ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        IReadOnlyList<SearchHit> hits = results.GetHits();
+
+        Assert.Equal(2, hits.Count);
+
+        SearchHit closest = hits[0];
+        Assert.Equal(2L, closest.Id);
+        Assert.Equal(0f, closest.Score);
+        Assert.Equal("two", closest.Fields["varchar"]);
+    }
+
+    [Fact]
+    public async Task SearchResults_GetHits_slices_by_query_for_multi_vector_search()
+    {
+        SearchResults results = await Collection.SearchAsync(
+            "float_vector",
+            new ReadOnlyMemory<float>[] { new[] { 3.5f, 4.5f }, new[] { 9f, 10f } },
+            SimilarityMetricType.L2,
+            limit: 1,
+            parameters: new SearchParameters { OutputFields = { "varchar" }, ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, results.NumQueries);
+
+        SearchHit firstQueryHit = Assert.Single(results.GetHits(0));
+        Assert.Equal(2L, firstQueryHit.Id);
+        Assert.Equal("two", firstQueryHit.Fields["varchar"]);
+
+        SearchHit secondQueryHit = Assert.Single(results.GetHits(1));
+        Assert.Equal(5L, secondQueryHit.Id);
+        Assert.Equal("five", secondQueryHit.Fields["varchar"]);
+    }
+
+    [Fact]
+    public async Task SearchResults_GetHits_rejects_out_of_range_queryIndex()
+    {
+        SearchResults results = await Collection.SearchAsync(
+            "float_vector",
+            new ReadOnlyMemory<float>[] { new[] { 3.5f, 4.5f } },
+            SimilarityMetricType.L2,
+            limit: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => results.GetHits(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => results.GetHits(-1));
+    }
+
+    [Fact]
+    public async Task SearchResults_GetHits_returns_empty_fields_without_OutputFields()
+    {
+        SearchResults results = await Collection.SearchAsync(
+            "float_vector",
+            new ReadOnlyMemory<float>[] { new[] { 3.5f, 4.5f } },
+            SimilarityMetricType.L2,
+            limit: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        SearchHit hit = Assert.Single(results.GetHits());
+        Assert.Equal(2L, hit.Id);
+        Assert.Empty(hit.Fields);
+    }
+}

--- a/Milvus.Client.Tests/RowResultsTests.cs
+++ b/Milvus.Client.Tests/RowResultsTests.cs
@@ -10,10 +10,14 @@ namespace Milvus.Client.Tests;
 public sealed class RowResultsTestsCollection;
 
 [Collection(nameof(RowResultsTests))]
-public class RowResultsTests(SearchQueryTests.QueryCollectionFixture queryCollectionFixture)
-    : IClassFixture<SearchQueryTests.QueryCollectionFixture>
+public class RowResultsTests(SearchQueryTests.QueryCollectionFixture queryCollectionFixture, MilvusFixture milvusFixture)
+    : IClassFixture<SearchQueryTests.QueryCollectionFixture>, IDisposable
 {
     private MilvusCollection Collection => queryCollectionFixture.Collection;
+
+    private readonly MilvusClient _stringPkClient = milvusFixture.CreateClient();
+
+    public void Dispose() => _stringPkClient.Dispose();
 
     [Fact]
     public async Task QueryRowsAsync_returns_one_dictionary_per_row()
@@ -122,5 +126,71 @@ public class RowResultsTests(SearchQueryTests.QueryCollectionFixture queryCollec
         SearchHit hit = Assert.Single(results.GetHits());
         Assert.Equal(2L, hit.Id);
         Assert.Empty(hit.Fields);
+    }
+
+    [Fact]
+    public async Task SearchResults_GetHits_returns_empty_list_for_a_zero_hit_query()
+    {
+        // An Expression that matches nothing pins the empty-result contract: GetHits should return an
+        // empty list rather than throwing, even though Limits reports 0 hits for this query.
+        SearchResults results = await Collection.SearchAsync(
+            "float_vector",
+            new ReadOnlyMemory<float>[] { new[] { 3.5f, 4.5f } },
+            SimilarityMetricType.L2,
+            limit: 2,
+            parameters: new SearchParameters { Expression = "id == -1", ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Empty(results.GetHits());
+    }
+
+    [Fact]
+    public async Task SearchResults_GetHits_covers_string_primary_key_and_fewer_hits_than_limit()
+    {
+        MilvusCollection collection = _stringPkClient.GetCollection(nameof(SearchResults_GetHits_covers_string_primary_key_and_fewer_hits_than_limit));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await _stringPkClient.CreateCollectionAsync(
+            collection.Name,
+            new[]
+            {
+                FieldSchema.CreateVarchar("id", 64, isPrimaryKey: true),
+                FieldSchema.CreateVarchar("tag", 64),
+                FieldSchema.CreateFloatVector("vec", 2),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.CreateIndexAsync(
+            "vec", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.InsertAsync(
+            new FieldData[]
+            {
+                FieldData.CreateVarChar("id", new[] { "a", "b" }),
+                FieldData.CreateVarChar("tag", new[] { "alpha", "beta" }),
+                FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new[] { 1f, 1f }, new[] { 2f, 2f } }),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // limit (5) is larger than the number of rows that actually exist (2) -- pins that GetHits
+        // slices by the server-reported hit count in Limits, not the requested limit.
+        SearchResults results = await collection.SearchAsync(
+            "vec",
+            new ReadOnlyMemory<float>[] { new[] { 1f, 1f } },
+            SimilarityMetricType.L2,
+            limit: 5,
+            parameters: new SearchParameters { OutputFields = { "tag" }, ConsistencyLevel = ConsistencyLevel.Strong },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        IReadOnlyList<SearchHit> hits = results.GetHits();
+
+        Assert.Equal(2, hits.Count);
+        Assert.Equal("a", hits[0].Id);
+        Assert.Equal("alpha", hits[0].Fields["tag"]);
+        Assert.Equal("b", hits[1].Id);
+        Assert.Equal("beta", hits[1].Fields["tag"]);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/Milvus.Client.Tests/RowResultsTests.cs
+++ b/Milvus.Client.Tests/RowResultsTests.cs
@@ -2,9 +2,10 @@ using Xunit;
 
 namespace Milvus.Client.Tests;
 
-// See TextTests's TextTestsCollection comment: Milvus 2.6.4 has proven unstable under concurrent
-// Search/Load-heavy activity from several tests at once. Kept out of the parallel pool defensively,
-// alongside TextTests/TextMatchTests/RunAnalyzerTests.
+// See TextTests's TextTestsCollection comment for the actual root cause of the server crashes that
+// motivated this: a Text field created without max_length, not concurrency. This class never creates
+// that shape, so it isn't known to trigger anything itself -- kept out of the parallel pool as
+// ordinary defense-in-depth alongside TextTests/TextMatchTests/RunAnalyzerTests.
 [CollectionDefinition(nameof(RowResultsTests), DisableParallelization = true)]
 public sealed class RowResultsTestsCollection;
 

--- a/Milvus.Client.Tests/RunAnalyzerTests.cs
+++ b/Milvus.Client.Tests/RunAnalyzerTests.cs
@@ -173,6 +173,35 @@ public class RunAnalyzerTests : IAsyncLifetime
         await collection.DropAsync(TestContext.Current.CancellationToken);
     }
 
+    [Fact]
+    public async Task Rejects_analyzerParams_together_with_collectionName_and_fieldName()
+    {
+        // Purely client-side validation -- no live server call is needed to hit this.
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            Client.RunAnalyzerAsync(
+                new[] { "hello" },
+                analyzerParams: new Dictionary<string, object> { ["type"] = "standard" },
+                collectionName: "some_collection",
+                fieldName: "some_field",
+                cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("mutually exclusive", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("some_collection", null)]
+    [InlineData(null, "some_field")]
+    public async Task Rejects_only_one_of_collectionName_and_fieldName(string? collectionName, string? fieldName)
+    {
+        // Purely client-side validation -- no live server call is needed to hit this.
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            Client.RunAnalyzerAsync(
+                new[] { "hello" },
+                collectionName: collectionName,
+                fieldName: fieldName,
+                cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("must be supplied together", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 5);
 
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;

--- a/Milvus.Client.Tests/RunAnalyzerTests.cs
+++ b/Milvus.Client.Tests/RunAnalyzerTests.cs
@@ -1,0 +1,184 @@
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+// See TextTests's TextTestsCollection comment: Milvus 2.6.4 has proven unstable under concurrent
+// schema-evolution-adjacent operations (BM25 function + analyzer setup, in this class's case) run from
+// several tests at once. Kept out of the parallel pool defensively, alongside TextTests.
+[CollectionDefinition(nameof(RunAnalyzerTests), DisableParallelization = true)]
+public sealed class RunAnalyzerTestsCollection;
+
+[Collection(nameof(RunAnalyzerTests))]
+public class RunAnalyzerTests : IAsyncLifetime
+{
+    private readonly MilvusClient Client;
+
+    public RunAnalyzerTests(MilvusFixture milvusFixture) => Client = milvusFixture.CreateClient();
+
+    [Fact]
+    public async Task Tokenizes_with_explicit_analyzer_params()
+    {
+        if (await Skip()) return;
+
+        var results = await Client.RunAnalyzerAsync(
+            new[] { "The quick foxes are running" },
+            new Dictionary<string, object> { ["type"] = "english" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var tokens = Assert.Single(results).Select(t => t.Token).ToList();
+        // The "english" analyzer stems and drops stop words -- "the"/"are" disappear, "foxes"/"running"
+        // are reduced to their stems.
+        Assert.Equal(new[] { "quick", "fox", "run" }, tokens);
+    }
+
+    [Fact]
+    public async Task Tokenizes_multiple_texts_in_order()
+    {
+        if (await Skip()) return;
+
+        var results = await Client.RunAnalyzerAsync(
+            new[] { "hello world", "goodbye world" },
+            new Dictionary<string, object> { ["type"] = "standard" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(new[] { "hello", "world" }, results[0].Select(t => t.Token));
+        Assert.Equal(new[] { "goodbye", "world" }, results[1].Select(t => t.Token));
+    }
+
+    [Fact]
+    public async Task Uses_a_default_analyzer_when_no_params_are_given()
+    {
+        if (await Skip()) return;
+
+        var results = await Client.RunAnalyzerAsync(
+            new[] { "hello world" }, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(new[] { "hello", "world" }, Assert.Single(results).Select(t => t.Token));
+    }
+
+    [Fact]
+    public async Task WithDetail_populates_offsets_and_position()
+    {
+        if (await Skip()) return;
+
+        var results = await Client.RunAnalyzerAsync(
+            new[] { "The Quick Brown Fox" },
+            new Dictionary<string, object> { ["type"] = "standard" },
+            withDetail: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        AnalyzerToken[] tokens = Assert.Single(results).ToArray();
+        Assert.Equal(4, tokens.Length);
+        Assert.Equal(("the", 0, 3, 0), (tokens[0].Token, tokens[0].StartOffset, tokens[0].EndOffset, tokens[0].Position));
+        Assert.Equal(("quick", 4, 9, 1), (tokens[1].Token, tokens[1].StartOffset, tokens[1].EndOffset, tokens[1].Position));
+        Assert.Equal(("brown", 10, 15, 2), (tokens[2].Token, tokens[2].StartOffset, tokens[2].EndOffset, tokens[2].Position));
+        Assert.Equal(("fox", 16, 19, 3), (tokens[3].Token, tokens[3].StartOffset, tokens[3].EndOffset, tokens[3].Position));
+    }
+
+    [Fact]
+    public async Task Without_detail_offsets_and_position_come_back_as_zero()
+    {
+        if (await Skip()) return;
+
+        var results = await Client.RunAnalyzerAsync(
+            new[] { "The Quick Brown Fox" },
+            new Dictionary<string, object> { ["type"] = "standard" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        AnalyzerToken token = Assert.Single(results).First();
+        Assert.Equal(0, token.StartOffset);
+        Assert.Equal(0, token.EndOffset);
+        Assert.Equal(0, token.Position);
+    }
+
+    [Fact]
+    public async Task WithHash_populates_hash()
+    {
+        if (await Skip()) return;
+
+        var withHash = await Client.RunAnalyzerAsync(
+            new[] { "hello" }, new Dictionary<string, object> { ["type"] = "standard" },
+            withHash: true, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.NotNull(Assert.Single(Assert.Single(withHash)).Hash);
+
+        var withoutHash = await Client.RunAnalyzerAsync(
+            new[] { "hello" }, new Dictionary<string, object> { ["type"] = "standard" },
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Null(Assert.Single(Assert.Single(withoutHash)).Hash);
+    }
+
+    [Fact]
+    public async Task Field_based_mode_works_for_a_bm25_input_field()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection(nameof(Field_based_mode_works_for_a_bm25_input_field));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        CollectionSchema schema = new();
+        schema.Fields.Add(FieldSchema.Create<long>("id", isPrimaryKey: true));
+        schema.Fields.Add(FieldSchema.CreateVarchar(
+            "text", 256, enableAnalyzer: true, analyzerParams: new Dictionary<string, object> { ["type"] = "english" }));
+        schema.Fields.Add(FieldSchema.CreateSparseFloatVector("sparse"));
+        schema.Functions.Add(FunctionSchema.CreateBm25("bm25_fn", "text", "sparse"));
+        await Client.CreateCollectionAsync(
+            nameof(Field_based_mode_works_for_a_bm25_input_field), schema, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.CreateIndexAsync(
+            "sparse", IndexType.SparseInvertedIndex, SimilarityMetricType.Bm25, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await Client.RunAnalyzerAsync(
+            new[] { "The quick foxes are running" },
+            collectionName: nameof(Field_based_mode_works_for_a_bm25_input_field),
+            fieldName: "text",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(new[] { "quick", "fox", "run" }, Assert.Single(results).Select(t => t.Token));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Field_based_mode_rejects_a_field_that_is_not_a_bm25_input()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection(nameof(Field_based_mode_rejects_a_field_that_is_not_a_bm25_input));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            nameof(Field_based_mode_rejects_a_field_that_is_not_a_bm25_input),
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateVarchar("text", 256, enableAnalyzer: true),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.CreateIndexAsync("vec", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            Client.RunAnalyzerAsync(
+                new[] { "hello world" },
+                collectionName: nameof(Field_based_mode_rejects_a_field_that_is_not_a_bm25_input),
+                fieldName: "text",
+                cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("bm25", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 5);
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Milvus.Client.Tests/RunAnalyzerTests.cs
+++ b/Milvus.Client.Tests/RunAnalyzerTests.cs
@@ -2,9 +2,10 @@ using Xunit;
 
 namespace Milvus.Client.Tests;
 
-// See TextTests's TextTestsCollection comment: Milvus 2.6.4 has proven unstable under concurrent
-// schema-evolution-adjacent operations (BM25 function + analyzer setup, in this class's case) run from
-// several tests at once. Kept out of the parallel pool defensively, alongside TextTests.
+// See TextTests's TextTestsCollection comment for the actual root cause of the server crashes that
+// motivated this: a Text field created without max_length, not concurrency. This class never creates
+// that shape, so it isn't known to trigger anything itself -- kept out of the parallel pool as
+// ordinary defense-in-depth alongside TextTests, not because of a finding specific to this class.
 [CollectionDefinition(nameof(RunAnalyzerTests), DisableParallelization = true)]
 public sealed class RunAnalyzerTestsCollection;
 

--- a/Milvus.Client.Tests/TextMatchTests.cs
+++ b/Milvus.Client.Tests/TextMatchTests.cs
@@ -1,0 +1,121 @@
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+// See TextTests's TextTestsCollection comment: Milvus 2.6.4 has proven unstable under concurrent
+// schema-evolution-adjacent operations (analyzer/match-enabled fields, in this class's case) run from
+// several tests at once. Kept out of the parallel pool defensively, alongside TextTests.
+[CollectionDefinition(nameof(TextMatchTests), DisableParallelization = true)]
+public sealed class TextMatchTestsCollection;
+
+[Collection(nameof(TextMatchTests))]
+public class TextMatchTests : IAsyncLifetime
+{
+    private readonly MilvusClient Client;
+
+    public TextMatchTests(MilvusFixture milvusFixture) => Client = milvusFixture.CreateClient();
+
+    [Fact]
+    public async Task TEXT_MATCH_finds_matching_rows()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateCollectionAsync(nameof(TEXT_MATCH_finds_matching_rows));
+
+        await collection.CreateIndexAsync("vec", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.InsertAsync(new FieldData[]
+        {
+            FieldData.Create("id", new long[] { 1, 2 }),
+            FieldData.CreateVarChar("tag", new[] { "quick brown", "slow lazy" }),
+            FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 }, new float[] { 2, 2, 2, 2 } }),
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await collection.QueryAsync(
+            "TEXT_MATCH(tag, 'lazy')", new QueryParameters { OutputFields = { "id" } },
+            cancellationToken: TestContext.Current.CancellationToken);
+        var field = (FieldData<long>)Assert.Single(results, f => f.FieldName == "id");
+        Assert.Equal(new long[] { 2 }, field.Data);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task TEXT_MATCH_rejected_without_EnableMatch()
+    {
+        if (await Skip()) return;
+
+        // Milvus 2.5.20 does not enforce this at all -- TEXT_MATCH works there even with EnableMatch
+        // left false, as long as EnableAnalyzer is set. The strict rejection is 2.6+ behavior.
+        if (await Client.GetParsedMilvusVersion() < new Version(2, 6))
+        {
+            return;
+        }
+
+        MilvusCollection collection = Client.GetCollection(nameof(TEXT_MATCH_rejected_without_EnableMatch));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        // EnableAnalyzer alone is not enough -- TEXT_MATCH specifically requires EnableMatch too.
+        await Client.CreateCollectionAsync(
+            nameof(TEXT_MATCH_rejected_without_EnableMatch),
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateVarchar("tag", 64, enableAnalyzer: true),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.CreateIndexAsync("vec", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.QueryAsync("TEXT_MATCH(tag, 'lazy')", cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("does not enable match", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Describe_round_trips_EnableMatch()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateCollectionAsync(nameof(Describe_round_trips_EnableMatch));
+
+        MilvusCollectionDescription description = await collection.DescribeAsync(TestContext.Current.CancellationToken);
+        FieldSchema field = description.Schema.Fields.Single(f => f.Name == "tag");
+        Assert.True(field.EnableMatch);
+        Assert.True(field.EnableAnalyzer);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<MilvusCollection> CreateCollectionAsync(string name)
+    {
+        MilvusCollection collection = Client.GetCollection(name);
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            name,
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateVarchar("tag", 64, enableAnalyzer: true, enableMatch: true),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        return collection;
+    }
+
+    private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 5);
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Milvus.Client.Tests/TextMatchTests.cs
+++ b/Milvus.Client.Tests/TextMatchTests.cs
@@ -79,6 +79,24 @@ public class TextMatchTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task EnableMatch_without_EnableAnalyzer_is_rejected_client_side()
+    {
+        // Purely client-side: EnableMatch's contract requires EnableAnalyzer, and FieldSchema.ToGrpc()
+        // enforces that itself before any request is sent, rather than letting the server reject it --
+        // so this throws synchronously and needs no live collection to actually be created.
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            Client.CreateCollectionAsync(
+                nameof(EnableMatch_without_EnableAnalyzer_is_rejected_client_side),
+                new[]
+                {
+                    FieldSchema.Create<long>("id", isPrimaryKey: true),
+                    FieldSchema.CreateVarchar("tag", 64, enableMatch: true),
+                    FieldSchema.CreateFloatVector("vec", 4),
+                }, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("EnableAnalyzer", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Describe_round_trips_EnableMatch()
     {
         if (await Skip()) return;

--- a/Milvus.Client.Tests/TextMatchTests.cs
+++ b/Milvus.Client.Tests/TextMatchTests.cs
@@ -2,9 +2,10 @@ using Xunit;
 
 namespace Milvus.Client.Tests;
 
-// See TextTests's TextTestsCollection comment: Milvus 2.6.4 has proven unstable under concurrent
-// schema-evolution-adjacent operations (analyzer/match-enabled fields, in this class's case) run from
-// several tests at once. Kept out of the parallel pool defensively, alongside TextTests.
+// See TextTests's TextTestsCollection comment for the actual root cause of the server crashes that
+// motivated this: a Text field created without max_length, not concurrency. This class never creates
+// that shape, so it isn't known to trigger anything itself -- kept out of the parallel pool as
+// ordinary defense-in-depth alongside TextTests, not because of a finding specific to this class.
 [CollectionDefinition(nameof(TextMatchTests), DisableParallelization = true)]
 public sealed class TextMatchTestsCollection;
 

--- a/Milvus.Client.Tests/TextMaxLengthCrashRegressionTests.cs
+++ b/Milvus.Client.Tests/TextMaxLengthCrashRegressionTests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+// Regression test for the server crash documented on TextTests's TextTestsCollection: a collection
+// with a Text field lacking max_length makes Milvus 2.6.4's streaming-node flusher panic and take the
+// whole server process down, on a delayed WAL-recovery pass rather than synchronously. Tracked upstream
+// at milvus-io/milvus#53291.
+//
+// This test deliberately creates that exact shape, so it runs against its own IsolatedMilvusFixture
+// container rather than MilvusFixture's assembly-wide shared one -- if the server does crash here (or
+// once the delayed panic eventually fires on this container), it only takes down this one test class,
+// not the other 280+ tests sharing the normal container.
+public class TextMaxLengthCrashRegressionTests : IClassFixture<IsolatedMilvusFixture>, IDisposable
+{
+    private readonly MilvusClient? Client;
+
+    public TextMaxLengthCrashRegressionTests(IsolatedMilvusFixture fixture)
+        => Client = fixture.IsAvailable ? fixture.CreateClient() : null;
+
+    public void Dispose() => Client?.Dispose();
+
+    [Fact]
+    public async Task Insert_without_max_length_fails()
+    {
+        // IsolatedMilvusFixture itself decides, from the MILVUS_IMAGE tag alone, whether this version
+        // is new enough to bother starting a container for -- Text (and this crash) is 2.6+. A null
+        // Client here means it decided no, so there's nothing to test on this CI image.
+        if (Client is null)
+        {
+            return;
+        }
+
+        MilvusCollection collection = Client.GetCollection(nameof(Insert_without_max_length_fails));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            nameof(Insert_without_max_length_fails),
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.Create("content", MilvusDataType.Text),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.InsertAsync(new FieldData[]
+            {
+                FieldData.Create("id", new long[] { 1 }),
+                FieldData.CreateText("content", new[] { "hello" }),
+                FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
+            }, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("max length", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Milvus.Client.Tests/TextMaxLengthCrashRegressionTests.cs
+++ b/Milvus.Client.Tests/TextMaxLengthCrashRegressionTests.cs
@@ -7,10 +7,12 @@ namespace Milvus.Client.Tests;
 // whole server process down, on a delayed WAL-recovery pass rather than synchronously. Tracked upstream
 // at milvus-io/milvus#53291.
 //
-// This test deliberately creates that exact shape, so it runs against its own IsolatedMilvusFixture
-// container rather than MilvusFixture's assembly-wide shared one -- if the server does crash here (or
-// once the delayed panic eventually fires on this container), it only takes down this one test class,
-// not the other 280+ tests sharing the normal container.
+// FieldSchema.ToGrpc() now rejects that exact shape client-side (for any field, not just ones built via
+// CreateText) -- see FieldSchema.CreateText's documentation -- so CreateCollectionAsync below never
+// actually reaches the server with it any more. This test still runs against its own IsolatedMilvusFixture
+// container rather than MilvusFixture's assembly-wide shared one: it's the one place deliberately
+// constructing the bad shape, so if the client-side guard is ever weakened or removed, the resulting
+// server crash takes down only this test class, not the other 280+ tests sharing the normal container.
 public class TextMaxLengthCrashRegressionTests : IClassFixture<IsolatedMilvusFixture>, IDisposable
 {
     private readonly MilvusClient? Client;
@@ -21,7 +23,7 @@ public class TextMaxLengthCrashRegressionTests : IClassFixture<IsolatedMilvusFix
     public void Dispose() => Client?.Dispose();
 
     [Fact]
-    public async Task Insert_without_max_length_fails()
+    public async Task CreateCollection_without_max_length_fails()
     {
         // IsolatedMilvusFixture itself decides, from the MILVUS_IMAGE tag alone, whether this version
         // is new enough to bother starting a container for -- Text (and this crash) is 2.6+. A null
@@ -31,27 +33,18 @@ public class TextMaxLengthCrashRegressionTests : IClassFixture<IsolatedMilvusFix
             return;
         }
 
-        MilvusCollection collection = Client.GetCollection(nameof(Insert_without_max_length_fails));
+        MilvusCollection collection = Client.GetCollection(nameof(CreateCollection_without_max_length_fails));
         await collection.DropAsync(TestContext.Current.CancellationToken);
 
-        await Client.CreateCollectionAsync(
-            nameof(Insert_without_max_length_fails),
-            new[]
-            {
-                FieldSchema.Create<long>("id", isPrimaryKey: true),
-                FieldSchema.Create("content", MilvusDataType.Text),
-                FieldSchema.CreateFloatVector("vec", 4),
-            }, cancellationToken: TestContext.Current.CancellationToken);
-
-        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
-            collection.InsertAsync(new FieldData[]
-            {
-                FieldData.Create("id", new long[] { 1 }),
-                FieldData.CreateText("content", new[] { "hello" }),
-                FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
-            }, cancellationToken: TestContext.Current.CancellationToken));
-        Assert.Contains("max length", exception.Message, StringComparison.OrdinalIgnoreCase);
-
-        await collection.DropAsync(TestContext.Current.CancellationToken);
+        ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            Client.CreateCollectionAsync(
+                nameof(CreateCollection_without_max_length_fails),
+                new[]
+                {
+                    FieldSchema.Create<long>("id", isPrimaryKey: true),
+                    FieldSchema.Create("content", MilvusDataType.Text),
+                    FieldSchema.CreateFloatVector("vec", 4),
+                }, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("MaxLength", exception.Message, StringComparison.Ordinal);
     }
 }

--- a/Milvus.Client.Tests/TextTests.cs
+++ b/Milvus.Client.Tests/TextTests.cs
@@ -1,0 +1,196 @@
+using Xunit;
+
+namespace Milvus.Client.Tests;
+
+// Milvus 2.6.4 crashes outright (process exits with SIGABRT) when two or more collections
+// containing a Text field are created/inserted/loaded concurrently -- reliably reproduced by running
+// this class's own tests in parallel with each other (confirmed via a minimal repro: 10 *sequential*
+// create/insert/load/drop cycles with a Text field never crash it, but running this class's 6 tests
+// together, which xunit v3 parallelizes by default, crashes it consistently). This is a server-side
+// bug, not something the client can work around -- keep this class out of the parallel pool so its
+// own tests, and the rest of the suite, aren't taken down by it.
+[CollectionDefinition(nameof(TextTests), DisableParallelization = true)]
+public sealed class TextTestsCollection;
+
+[Collection(nameof(TextTests))]
+public class TextTests : IAsyncLifetime
+{
+    private readonly MilvusClient Client;
+
+    public TextTests(MilvusFixture milvusFixture) => Client = milvusFixture.CreateClient();
+
+    [Fact]
+    public async Task Insert_and_query_round_trip()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateCollectionAsync(nameof(Insert_and_query_round_trip));
+
+        await collection.CreateIndexAsync("vec", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.InsertAsync(new FieldData[]
+        {
+            FieldData.Create("id", new long[] { 1 }),
+            FieldData.CreateText("content", new[] { "hello text world" }),
+            FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await collection.QueryAsync(
+            "id == 1", new QueryParameters { OutputFields = { "content" } }, cancellationToken: TestContext.Current.CancellationToken);
+        var field = (FieldData<string?>)Assert.Single(results, f => f.FieldName == "content");
+        Assert.Equal("hello text world", Assert.Single(field.Data));
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Describe_round_trips_properties()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = await CreateCollectionAsync(nameof(Describe_round_trips_properties));
+
+        MilvusCollectionDescription description = await collection.DescribeAsync(TestContext.Current.CancellationToken);
+        FieldSchema field = description.Schema.Fields.Single(f => f.Name == "content");
+
+        Assert.Equal(MilvusDataType.Text, field.DataType);
+        Assert.Equal(1000, field.MaxLength);
+        Assert.True(field.EnableAnalyzer);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Insert_without_max_length_fails()
+    {
+        if (await Skip()) return;
+
+        // Milvus does not enforce max_length for a Text field at collection-creation time, but every
+        // insert into the field then fails -- confirmed against 2.6.4. FieldSchema.CreateText requires
+        // maxLength to avoid this trap; this test bypasses that via the general Create(...) overload to
+        // confirm the underlying server behavior it protects against still holds.
+        MilvusCollection collection = Client.GetCollection(nameof(Insert_without_max_length_fails));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            nameof(Insert_without_max_length_fails),
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.Create("content", MilvusDataType.Text),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.InsertAsync(new FieldData[]
+            {
+                FieldData.Create("id", new long[] { 1 }),
+                FieldData.CreateText("content", new[] { "hello" }),
+                FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
+            }, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("max length", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Rejects_as_primary_key()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection(nameof(Rejects_as_primary_key));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<MilvusException>(() =>
+            Client.CreateCollectionAsync(
+                nameof(Rejects_as_primary_key),
+                new[]
+                {
+                    FieldSchema.Create("id", MilvusDataType.Text, isPrimaryKey: true),
+                    FieldSchema.CreateFloatVector("vec", 4),
+                }, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Rejects_default_value()
+    {
+        if (await Skip()) return;
+
+        MilvusCollection collection = Client.GetCollection(nameof(Rejects_default_value));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        // FieldSchema.CreateText has no defaultValue parameter; go through the general overload to confirm
+        // the server (not just the client) rejects it -- consistent with Milvus's documented "no default
+        // values" restriction for Text fields. Milvus itself doesn't get a chance to weigh in here: our
+        // own FieldSchema.ToGrpc-equivalent conversion rejects it client-side first.
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            Client.CreateCollectionAsync(
+                nameof(Rejects_default_value),
+                new[]
+                {
+                    FieldSchema.Create<long>("id", isPrimaryKey: true),
+                    FieldSchema.Create("content", MilvusDataType.Text, nullable: true, defaultValue: "fallback"),
+                    FieldSchema.CreateFloatVector("vec", 4),
+                }, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task TEXT_MATCH_is_currently_rejected()
+    {
+        if (await Skip()) return;
+
+        // Unlike VarChar (see TextMatchTests), Milvus rejects any filter expression -- TEXT_MATCH
+        // included -- against a Text field outright, even with EnableMatch and EnableAnalyzer both set.
+        // Confirmed against 2.6.4: "filter on text field (...) is not supported yet". This test fails
+        // loudly if that ever changes, so the docs here don't go stale silently.
+        MilvusCollection collection = Client.GetCollection(nameof(TEXT_MATCH_is_currently_rejected));
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            nameof(TEXT_MATCH_is_currently_rejected),
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateText("content", 1000, enableAnalyzer: true, enableMatch: true),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        await collection.CreateIndexAsync("vec", IndexType.Flat, SimilarityMetricType.L2, cancellationToken: TestContext.Current.CancellationToken);
+        await collection.LoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await collection.WaitForCollectionLoadAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+            collection.QueryAsync("TEXT_MATCH(content, 'fox')", cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Contains("not supported", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<MilvusCollection> CreateCollectionAsync(string name)
+    {
+        MilvusCollection collection = Client.GetCollection(name);
+        await collection.DropAsync(TestContext.Current.CancellationToken);
+
+        await Client.CreateCollectionAsync(
+            name,
+            new[]
+            {
+                FieldSchema.Create<long>("id", isPrimaryKey: true),
+                FieldSchema.CreateText("content", 1000, enableAnalyzer: true),
+                FieldSchema.CreateFloatVector("vec", 4),
+            }, cancellationToken: TestContext.Current.CancellationToken);
+
+        return collection;
+    }
+
+    private async Task<bool> Skip() => await Client.GetParsedMilvusVersion() < new Version(2, 6);
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Milvus.Client.Tests/TextTests.cs
+++ b/Milvus.Client.Tests/TextTests.cs
@@ -2,13 +2,27 @@ using Xunit;
 
 namespace Milvus.Client.Tests;
 
-// Milvus 2.6.4 crashes outright (process exits with SIGABRT) when two or more collections
-// containing a Text field are created/inserted/loaded concurrently -- reliably reproduced by running
-// this class's own tests in parallel with each other (confirmed via a minimal repro: 10 *sequential*
-// create/insert/load/drop cycles with a Text field never crash it, but running this class's 6 tests
-// together, which xunit v3 parallelizes by default, crashes it consistently). This is a server-side
-// bug, not something the client can work around -- keep this class out of the parallel pool so its
-// own tests, and the rest of the suite, aren't taken down by it.
+// Root-caused via a live container's own logs (docker logs, not just client-side symptoms): Milvus
+// 2.6.4's streaming-node flusher unrecoverably panics -- crashing the entire server process, not just
+// the request -- when it processes a collection containing a Text field with no max_length:
+//
+//   panic: new a empty data sync service should never be failed, the max_length was not specified,
+//   field type is Text
+//     .../flushcommon/pipeline.NewEmptyStreamingNodeDataSyncService(...)
+//     .../flusherimpl.(*flusherComponents).WhenCreateCollection(...)
+//     .../flusherimpl.(*WALFlusherImpl).dispatch(...)
+//     created by .../flusherimpl.RecoverWALFlusher
+//
+// The call stack (RecoverWALFlusher) means this doesn't fire synchronously on CreateCollectionAsync --
+// it fires whenever the flusher subsystem next recovers/rescans WAL channels, which can happen a good
+// while after the offending collection was created (and even after it was dropped again, if the
+// recovery pass catches it mid-window). That delay is why this looked like a "concurrency" issue in
+// earlier investigation: the crash surfaces later, taking out whatever happens to be running at that
+// point, not necessarily whatever created the bad collection. FieldSchema.CreateText requires
+// maxLength for exactly this reason -- no code going through the public API can hit this -- so this
+// class does not exercise the bad shape live; see FieldSchema.CreateText's XML doc for the client-side
+// contract this protects. Kept out of the parallel pool as ordinary defense-in-depth, not because this
+// class's own tests are known to trigger anything themselves.
 [CollectionDefinition(nameof(TextTests), DisableParallelization = true)]
 public sealed class TextTestsCollection;
 
@@ -61,38 +75,40 @@ public class TextTests : IAsyncLifetime
         await collection.DropAsync(TestContext.Current.CancellationToken);
     }
 
-    [Fact]
-    public async Task Insert_without_max_length_fails()
-    {
-        if (await Skip()) return;
-
-        // Milvus does not enforce max_length for a Text field at collection-creation time, but every
-        // insert into the field then fails -- confirmed against 2.6.4. FieldSchema.CreateText requires
-        // maxLength to avoid this trap; this test bypasses that via the general Create(...) overload to
-        // confirm the underlying server behavior it protects against still holds.
-        MilvusCollection collection = Client.GetCollection(nameof(Insert_without_max_length_fails));
-        await collection.DropAsync(TestContext.Current.CancellationToken);
-
-        await Client.CreateCollectionAsync(
-            nameof(Insert_without_max_length_fails),
-            new[]
-            {
-                FieldSchema.Create<long>("id", isPrimaryKey: true),
-                FieldSchema.Create("content", MilvusDataType.Text),
-                FieldSchema.CreateFloatVector("vec", 4),
-            }, cancellationToken: TestContext.Current.CancellationToken);
-
-        MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
-            collection.InsertAsync(new FieldData[]
-            {
-                FieldData.Create("id", new long[] { 1 }),
-                FieldData.CreateText("content", new[] { "hello" }),
-                FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
-            }, cancellationToken: TestContext.Current.CancellationToken));
-        Assert.Contains("max length", exception.Message, StringComparison.OrdinalIgnoreCase);
-
-        await collection.DropAsync(TestContext.Current.CancellationToken);
-    }
+    // Disabled, not deleted: creating this exact collection shape (a Text field with no max_length) is
+    // what triggers the server panic documented above, so running it against the shared test container
+    // crashes it for every other test. FieldSchema.CreateText's XML doc is the source of truth for this
+    // behavior in the meantime. Re-enable once milvus-io/milvus#53291 is fixed upstream, or if this ever
+    // needs to be re-verified against a disposable, non-shared container.
+    //
+    // [Fact]
+    // public async Task Insert_without_max_length_fails()
+    // {
+    //     if (await Skip()) return;
+    //
+    //     MilvusCollection collection = Client.GetCollection(nameof(Insert_without_max_length_fails));
+    //     await collection.DropAsync(TestContext.Current.CancellationToken);
+    //
+    //     await Client.CreateCollectionAsync(
+    //         nameof(Insert_without_max_length_fails),
+    //         new[]
+    //         {
+    //             FieldSchema.Create<long>("id", isPrimaryKey: true),
+    //             FieldSchema.Create("content", MilvusDataType.Text),
+    //             FieldSchema.CreateFloatVector("vec", 4),
+    //         }, cancellationToken: TestContext.Current.CancellationToken);
+    //
+    //     MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
+    //         collection.InsertAsync(new FieldData[]
+    //         {
+    //             FieldData.Create("id", new long[] { 1 }),
+    //             FieldData.CreateText("content", new[] { "hello" }),
+    //             FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
+    //         }, cancellationToken: TestContext.Current.CancellationToken));
+    //     Assert.Contains("max length", exception.Message, StringComparison.OrdinalIgnoreCase);
+    //
+    //     await collection.DropAsync(TestContext.Current.CancellationToken);
+    // }
 
     [Fact]
     public async Task Rejects_as_primary_key()

--- a/Milvus.Client.Tests/TextTests.cs
+++ b/Milvus.Client.Tests/TextTests.cs
@@ -75,9 +75,9 @@ public class TextTests : IAsyncLifetime
         await collection.DropAsync(TestContext.Current.CancellationToken);
     }
 
-    // "Insert without max_length fails" is deliberately not tested here: creating that exact collection
-    // shape (a Text field with no max_length) is what triggers the server panic documented above, so it
-    // runs against its own dedicated, disposable container instead of this shared one -- see
+    // "Create collection without max_length fails" is deliberately not tested here: creating that exact
+    // collection shape (a Text field with no max_length) is what triggers the server panic documented
+    // above, so it runs against its own dedicated, disposable container instead of this shared one -- see
     // TextMaxLengthCrashRegressionTests.
 
     [Fact]
@@ -88,12 +88,15 @@ public class TextTests : IAsyncLifetime
         MilvusCollection collection = Client.GetCollection(nameof(Rejects_as_primary_key));
         await collection.DropAsync(TestContext.Current.CancellationToken);
 
+        FieldSchema idField = FieldSchema.Create("id", MilvusDataType.Text, isPrimaryKey: true);
+        idField.MaxLength = 100;
+
         await Assert.ThrowsAsync<MilvusException>(() =>
             Client.CreateCollectionAsync(
                 nameof(Rejects_as_primary_key),
                 new[]
                 {
-                    FieldSchema.Create("id", MilvusDataType.Text, isPrimaryKey: true),
+                    idField,
                     FieldSchema.CreateFloatVector("vec", 4),
                 }, cancellationToken: TestContext.Current.CancellationToken));
     }

--- a/Milvus.Client.Tests/TextTests.cs
+++ b/Milvus.Client.Tests/TextTests.cs
@@ -75,40 +75,10 @@ public class TextTests : IAsyncLifetime
         await collection.DropAsync(TestContext.Current.CancellationToken);
     }
 
-    // Disabled, not deleted: creating this exact collection shape (a Text field with no max_length) is
-    // what triggers the server panic documented above, so running it against the shared test container
-    // crashes it for every other test. FieldSchema.CreateText's XML doc is the source of truth for this
-    // behavior in the meantime. Re-enable once milvus-io/milvus#53291 is fixed upstream, or if this ever
-    // needs to be re-verified against a disposable, non-shared container.
-    //
-    // [Fact]
-    // public async Task Insert_without_max_length_fails()
-    // {
-    //     if (await Skip()) return;
-    //
-    //     MilvusCollection collection = Client.GetCollection(nameof(Insert_without_max_length_fails));
-    //     await collection.DropAsync(TestContext.Current.CancellationToken);
-    //
-    //     await Client.CreateCollectionAsync(
-    //         nameof(Insert_without_max_length_fails),
-    //         new[]
-    //         {
-    //             FieldSchema.Create<long>("id", isPrimaryKey: true),
-    //             FieldSchema.Create("content", MilvusDataType.Text),
-    //             FieldSchema.CreateFloatVector("vec", 4),
-    //         }, cancellationToken: TestContext.Current.CancellationToken);
-    //
-    //     MilvusException exception = await Assert.ThrowsAsync<MilvusException>(() =>
-    //         collection.InsertAsync(new FieldData[]
-    //         {
-    //             FieldData.Create("id", new long[] { 1 }),
-    //             FieldData.CreateText("content", new[] { "hello" }),
-    //             FieldData.CreateFloatVector("vec", new ReadOnlyMemory<float>[] { new float[] { 1, 1, 1, 1 } }),
-    //         }, cancellationToken: TestContext.Current.CancellationToken));
-    //     Assert.Contains("max length", exception.Message, StringComparison.OrdinalIgnoreCase);
-    //
-    //     await collection.DropAsync(TestContext.Current.CancellationToken);
-    // }
+    // "Insert without max_length fails" is deliberately not tested here: creating that exact collection
+    // shape (a Text field with no max_length) is what triggers the server panic documented above, so it
+    // runs against its own dedicated, disposable container instead of this shared one -- see
+    // TextMaxLengthCrashRegressionTests.
 
     [Fact]
     public async Task Rejects_as_primary_key()

--- a/Milvus.Client/AnalyzerToken.cs
+++ b/Milvus.Client/AnalyzerToken.cs
@@ -1,0 +1,50 @@
+namespace Milvus.Client;
+
+/// <summary>
+/// A single token produced by running a text analyzer over an input string, via
+/// <see cref="MilvusClient.RunAnalyzerAsync" />.
+/// </summary>
+public sealed class AnalyzerToken
+{
+    internal AnalyzerToken(string token, long startOffset, long endOffset, long position, long positionLength, uint? hash)
+    {
+        Token = token;
+        StartOffset = startOffset;
+        EndOffset = endOffset;
+        Position = position;
+        PositionLength = positionLength;
+        Hash = hash;
+    }
+
+    /// <summary>
+    /// The token text produced by the analyzer, e.g. a single word after tokenization and any configured
+    /// filters (lowercasing, stemming, stop-word removal, ...).
+    /// </summary>
+    public string Token { get; }
+
+    /// <summary>
+    /// The byte offset of the token's start in the original input string.
+    /// </summary>
+    public long StartOffset { get; }
+
+    /// <summary>
+    /// The byte offset of the token's end in the original input string.
+    /// </summary>
+    public long EndOffset { get; }
+
+    /// <summary>
+    /// The token's position (its index among tokens produced from the input), used for phrase matching.
+    /// </summary>
+    public long Position { get; }
+
+    /// <summary>
+    /// The number of positions this token spans. Normally 1; a token produced by some filters (e.g. a
+    /// synonym or shingle expansion) can span more than one position.
+    /// </summary>
+    public long PositionLength { get; }
+
+    /// <summary>
+    /// The token's hash, if requested via <c>withHash</c>; <see langword="null" /> otherwise.
+    /// </summary>
+    public uint? Hash { get; }
+}

--- a/Milvus.Client/ByteStringFieldData.cs
+++ b/Milvus.Client/ByteStringFieldData.cs
@@ -44,4 +44,7 @@ public sealed class ByteStringFieldData : FieldData
 
     internal override object GetValueAsObject(int index)
         => throw new NotSupportedException("Dynamic ByteString fields are not supported");
+
+    internal override object GetRowValue(int index)
+        => throw new NotSupportedException("ByteStringFieldData holds a single raw vector, not row-oriented data");
 }

--- a/Milvus.Client/Constants.cs
+++ b/Milvus.Client/Constants.cs
@@ -201,4 +201,10 @@ internal static class Constants
     /// Key name in type_params. Contains analyzer parameters as JSON.
     /// </summary>
     internal const string AnalyzerParams = "analyzer_params";
+
+    /// <summary>
+    /// Key name in type_params. Indicates whether an inverted index for TEXT_MATCH filtering is built for
+    /// this field.
+    /// </summary>
+    internal const string EnableMatch = "enable_match";
 }

--- a/Milvus.Client/FieldData.cs
+++ b/Milvus.Client/FieldData.cs
@@ -60,7 +60,19 @@ public abstract class FieldData
     /// The value at <paramref name="index" /> as a boxed object, used to pack dynamic fields into the
     /// <c>$meta</c> JSON column. Null when the column is nullable and has no value for that row.
     /// </summary>
+    /// <remarks>
+    /// Vector-typed subclasses throw here -- a vector cannot itself be packed into the JSON
+    /// <c>$meta</c> column. For a row-value accessor that also works on vector columns, see
+    /// <see cref="GetRowValue" />.
+    /// </remarks>
     internal abstract object? GetValueAsObject(int index);
+
+    /// <summary>
+    /// The value at <paramref name="index" /> as a boxed object, used to pivot a column-oriented query
+    /// or search result into row-oriented dictionaries. Unlike <see cref="GetValueAsObject" />, this
+    /// works for every field type including vectors -- there is no JSON-serialization constraint here.
+    /// </summary>
+    internal abstract object? GetRowValue(int index);
 
     /// <summary>
     /// Get string data.
@@ -720,6 +732,9 @@ public class FieldData<TData> : FieldData
     /// Vector data
     /// </summary>
     public IReadOnlyList<TData> Data { get; set; }
+
+    /// <inheritdoc />
+    internal override object? GetRowValue(int index) => Data[index];
 
     /// <summary>
     /// Row count

--- a/Milvus.Client/FieldData.cs
+++ b/Milvus.Client/FieldData.cs
@@ -173,6 +173,13 @@ public abstract class FieldData
                     { DataCase: ScalarField.DataOneofCase.StringData }
                         when fieldData.Type == Grpc.DataType.Timestamptz
                         => CreateTimestamptz(fieldData.FieldName, fieldData.Scalars.StringData.Data, fieldData.IsDynamic),
+                    // Text also shares the string_data slot with VarChar (verified against Milvus 2.6.4).
+                    { DataCase: ScalarField.DataOneofCase.StringData }
+                        when fieldData.Type == Grpc.DataType.Text && hasValidData
+                        => CreateText(fieldData.FieldName, ApplyValidMask(fieldData.Scalars.StringData.Data, fieldData.ValidData), fieldData.IsDynamic),
+                    { DataCase: ScalarField.DataOneofCase.StringData }
+                        when fieldData.Type == Grpc.DataType.Text
+                        => CreateText(fieldData.FieldName, fieldData.Scalars.StringData.Data, fieldData.IsDynamic),
                     { DataCase: ScalarField.DataOneofCase.StringData } when hasValidData
                         => CreateVarChar(fieldData.FieldName, ApplyValidMask(fieldData.Scalars.StringData.Data, fieldData.ValidData), fieldData.IsDynamic),
                     { DataCase: ScalarField.DataOneofCase.StringData }
@@ -371,6 +378,18 @@ public abstract class FieldData
         IReadOnlyList<string?> data,
         bool isDynamic = false)
         => new(fieldName, data, MilvusDataType.VarChar, isDynamic);
+
+    /// <summary>
+    /// Create a <see cref="MilvusDataType.Text" /> field. Available since Milvus v2.6.
+    /// </summary>
+    /// <param name="fieldName">Field name.</param>
+    /// <param name="data">Data in this field. Values can be null if the field is nullable.</param>
+    /// <param name="isDynamic">Whether the field is dynamic.</param>
+    public static FieldData<string?> CreateText(
+        string fieldName,
+        IReadOnlyList<string?> data,
+        bool isDynamic = false)
+        => new(fieldName, data, MilvusDataType.Text, isDynamic);
 
     /// <summary>
     /// Create array of elements.
@@ -972,6 +991,32 @@ public class FieldData<TData> : FieldData
                 fieldData.Scalars = new Grpc.ScalarField { StringData = timestamptzData };
                 break;
 
+            // Text travels in string_data (same slot as VarChar), verified against Milvus 2.6.4.
+            case MilvusDataType.Text:
+                Grpc.StringArray textData = new();
+                bool hasNullText = Data.Any(item => item is null);
+                if (hasNullText)
+                {
+                    foreach (string? item in (IReadOnlyList<string?>)Data)
+                    {
+                        if (item is null)
+                        {
+                            fieldData.ValidData.Add(false);
+                        }
+                        else
+                        {
+                            fieldData.ValidData.Add(true);
+                            textData.Data.Add(item);
+                        }
+                    }
+                }
+                else
+                {
+                    textData.Data.AddRange((IReadOnlyList<string>)Data);
+                }
+                fieldData.Scalars = new Grpc.ScalarField { StringData = textData };
+                break;
+
             case MilvusDataType.Geometry:
                 Grpc.GeometryWktArray geometryData = new();
                 bool hasNullGeometry = Data.Any(item => item is null);
@@ -1014,7 +1059,7 @@ public class FieldData<TData> : FieldData
             MilvusDataType.Bool or MilvusDataType.Int8 or MilvusDataType.Int16 or MilvusDataType.Int32
                 or MilvusDataType.Int64 or MilvusDataType.Float or MilvusDataType.Double
                 or MilvusDataType.String or MilvusDataType.VarChar or MilvusDataType.Json
-                or MilvusDataType.Geometry or MilvusDataType.Timestamptz
+                or MilvusDataType.Geometry or MilvusDataType.Timestamptz or MilvusDataType.Text
                 => Data[index],
 
             MilvusDataType.None => throw new MilvusException($"DataType Error:{DataType}"),

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -233,10 +233,23 @@ public sealed class FieldSchema
     /// </summary>
     /// <param name="name">The field name.</param>
     /// <param name="maxLength">
-    /// The maximum length of the field. Milvus does not enforce this at collection-creation time -- a
-    /// <see cref="MilvusDataType.Text" /> field can be created without it -- but every insert into the
-    /// field then fails with "max length not found", so it is required here to avoid that trap. Verified
-    /// against Milvus 2.6.4.
+    /// The maximum length of the field. Milvus's own schema validation does not enforce this at
+    /// collection-creation time, and a request omitting it is accepted -- but doing so is far more
+    /// dangerous than a mere validation gap. Root-caused against a live Milvus 2.6.4 container (via the
+    /// server's own logs, not just symptoms): its streaming-node flusher unrecoverably panics --
+    /// crashing the <em>entire server process</em>, not just the one request -- the next time it
+    /// recovers/rescans WAL channels and finds a collection with a <see cref="MilvusDataType.Text" />
+    /// field lacking this value:
+    /// <code>
+    /// panic: new a empty data sync service should never be failed, the max_length was not specified, field type is Text
+    ///   .../flushcommon/pipeline.NewEmptyStreamingNodeDataSyncService(...)
+    ///   .../flusherimpl.(*flusherComponents).WhenCreateCollection(...)
+    ///   created by .../flusherimpl.RecoverWALFlusher
+    /// </code>
+    /// Because that recovery pass can run well after the collection was created (even after it was
+    /// dropped again, if the pass catches it mid-window), the crash can surface much later and appear
+    /// to hit an unrelated, unlucky operation. <c>maxLength</c> is required here specifically to make
+    /// this unreachable through the public API -- there is no supported way to opt out of it.
     /// </param>
     /// <param name="description">An optional description for the field.</param>
     /// <param name="nullable">Whether the field can contain null values.</param>

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -113,10 +113,15 @@ public sealed class FieldSchema
     /// The default value for the field. Available since Milvus v2.5.
     /// </param>
     /// <param name="enableAnalyzer">
-    /// Whether to enable the analyzer for this field. Required for BM25 full-text search input fields.
+    /// Whether to enable the analyzer for this field. Required for BM25 full-text search input fields
+    /// and for <paramref name="enableMatch" />-based <c>TEXT_MATCH</c> filtering.
     /// </param>
     /// <param name="analyzerParams">
     /// Optional analyzer parameters. For example: <c>new Dictionary&lt;string, object&gt; { ["type"] = "english" }</c>.
+    /// </param>
+    /// <param name="enableMatch">
+    /// Whether to build an inverted index enabling <c>TEXT_MATCH</c> filter expressions against this
+    /// field. Available since Milvus v2.5. Requires <paramref name="enableAnalyzer" /> to also be true.
     /// </param>
     public static FieldSchema CreateVarchar(
         string name,
@@ -128,12 +133,14 @@ public sealed class FieldSchema
         bool nullable = false,
         string? defaultValue = null,
         bool enableAnalyzer = false,
-        IReadOnlyDictionary<string, object>? analyzerParams = null)
+        IReadOnlyDictionary<string, object>? analyzerParams = null,
+        bool enableMatch = false)
         => new(name, MilvusDataType.VarChar, isPrimaryKey, autoId, isPartitionKey, description, nullable, defaultValue)
         {
             MaxLength = maxLength,
             EnableAnalyzer = enableAnalyzer,
-            AnalyzerParams = analyzerParams
+            AnalyzerParams = analyzerParams,
+            EnableMatch = enableMatch
         };
 
     /// <summary>
@@ -216,6 +223,55 @@ public sealed class FieldSchema
     /// </remarks>
     public static FieldSchema CreateTimestamptz(string name, string description = "", bool nullable = false)
         => new(name, MilvusDataType.Timestamptz, description: description, nullable: nullable);
+
+    /// <summary>
+    /// Create a field schema for a <c>text</c> field. Available since Milvus v2.6. Intended for longer
+    /// free-form content than <c>varchar</c>; shares the same wire representation, but cannot be a
+    /// primary key, a partition key, or an array element type, and does not support a default value.
+    /// </summary>
+    /// <param name="name">The field name.</param>
+    /// <param name="maxLength">
+    /// The maximum length of the field. Milvus does not enforce this at collection-creation time -- a
+    /// <see cref="MilvusDataType.Text" /> field can be created without it -- but every insert into the
+    /// field then fails with "max length not found", so it is required here to avoid that trap. Verified
+    /// against Milvus 2.6.4.
+    /// </param>
+    /// <param name="description">An optional description for the field.</param>
+    /// <param name="nullable">Whether the field can contain null values.</param>
+    /// <param name="enableAnalyzer">
+    /// Whether to enable the analyzer for this field. Required for BM25 full-text search input fields
+    /// and for <paramref name="enableMatch" />-based <c>TEXT_MATCH</c> filtering.
+    /// </param>
+    /// <param name="analyzerParams">
+    /// Optional analyzer parameters. For example: <c>new Dictionary&lt;string, object&gt; { ["type"] = "english" }</c>.
+    /// </param>
+    /// <param name="enableMatch">
+    /// Whether to build an inverted index enabling <c>TEXT_MATCH</c> filter expressions against this
+    /// field. Requires <paramref name="enableAnalyzer" /> to also be true.
+    /// <para>
+    /// As of Milvus 2.6.4, <c>TEXT_MATCH</c> (and every other filter expression) against a
+    /// <see cref="MilvusDataType.Text" /> field is rejected server-side with "filter on text field (...)
+    /// is not supported yet", regardless of this setting -- filtering by content currently requires a
+    /// <see cref="MilvusDataType.VarChar" /> field instead. The field can still be created, inserted
+    /// into, and read back (including via <c>OutputFields</c>); only expression-based filtering on it is
+    /// blocked. Revisit once a newer Milvus version lifts this restriction.
+    /// </para>
+    /// </param>
+    public static FieldSchema CreateText(
+        string name,
+        int maxLength,
+        string description = "",
+        bool nullable = false,
+        bool enableAnalyzer = false,
+        IReadOnlyDictionary<string, object>? analyzerParams = null,
+        bool enableMatch = false)
+        => new(name, MilvusDataType.Text, description: description, nullable: nullable)
+        {
+            MaxLength = maxLength,
+            EnableAnalyzer = enableAnalyzer,
+            AnalyzerParams = analyzerParams,
+            EnableMatch = enableMatch
+        };
 
     /// <summary>
     /// Create a field schema for a sparse float vector field. Available since Milvus v2.4.
@@ -418,11 +474,13 @@ public sealed class FieldSchema
     public int? Dimension { get; set; }
 
     /// <summary>
-    /// Whether to enable the analyzer for this field. Required for BM25 full-text search input fields.
+    /// Whether to enable the analyzer for this field. Required for BM25 full-text search input fields
+    /// and for <see cref="EnableMatch" />-based <c>TEXT_MATCH</c> filtering.
     /// </summary>
     /// <remarks>
     /// When enabled, the field can be used as an input to a BM25 function for full-text search.
-    /// This property is only applicable for <see cref="MilvusDataType.VarChar" /> fields.
+    /// This property is only applicable for <see cref="MilvusDataType.VarChar" /> and
+    /// <see cref="MilvusDataType.Text" /> fields.
     /// </remarks>
     public bool EnableAnalyzer { get; set; }
 
@@ -433,6 +491,23 @@ public sealed class FieldSchema
     /// This property is only applicable when <see cref="EnableAnalyzer" /> is set to true.
     /// </remarks>
     public IReadOnlyDictionary<string, object>? AnalyzerParams { get; set; }
+
+    /// <summary>
+    /// Whether to build an inverted index enabling <c>TEXT_MATCH</c> filter expressions against this
+    /// field. Available since Milvus v2.5.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Requires <see cref="EnableAnalyzer" /> to also be set to <see langword="true" /> -- Milvus rejects a
+    /// <c>TEXT_MATCH</c> filter against a field where match is not enabled with an error naming the field,
+    /// e.g. <c>field "x" does not enable match</c> (verified against Milvus 2.6.4).
+    /// </para>
+    /// <para>
+    /// This property is only applicable for <see cref="MilvusDataType.VarChar" /> and
+    /// <see cref="MilvusDataType.Text" /> fields.
+    /// </para>
+    /// </remarks>
+    public bool EnableMatch { get; set; }
 
     /// <summary>
     /// Whether this field is the output of a function and should not be provided during insertion.

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -561,6 +561,14 @@ public sealed class FieldSchema
                 $"{nameof(CreateText)}, instead of the general {nameof(Create)} overload.");
         }
 
+        if (EnableMatch && !EnableAnalyzer)
+        {
+            throw new ArgumentException(
+                $"Field '{Name}' has {nameof(EnableMatch)} set without {nameof(EnableAnalyzer)}. " +
+                $"{nameof(EnableMatch)} requires {nameof(EnableAnalyzer)} to also be true -- see " +
+                $"{nameof(EnableMatch)}'s documentation.");
+        }
+
         Grpc.FieldSchema grpcField = new()
         {
             Name = Name,

--- a/Milvus.Client/FieldSchema.cs
+++ b/Milvus.Client/FieldSchema.cs
@@ -249,7 +249,11 @@ public sealed class FieldSchema
     /// Because that recovery pass can run well after the collection was created (even after it was
     /// dropped again, if the pass catches it mid-window), the crash can surface much later and appear
     /// to hit an unrelated, unlucky operation. <c>maxLength</c> is required here specifically to make
-    /// this unreachable through the public API -- there is no supported way to opt out of it.
+    /// this unreachable through the public API -- there is no supported way to opt out of it. The
+    /// general <see cref="Create(string, MilvusDataType, bool, bool, bool, string, bool, object?)" />
+    /// overload still accepts a <see cref="MilvusDataType.Text" /> field with no <see cref="MaxLength" />
+    /// set (it has no maxLength parameter to require one through), so <see cref="ToGrpc" /> itself rejects
+    /// that shape for any field, regardless of which factory built it.
     /// </param>
     /// <param name="description">An optional description for the field.</param>
     /// <param name="nullable">Whether the field can contain null values.</param>
@@ -547,6 +551,16 @@ public sealed class FieldSchema
     /// </summary>
     internal Grpc.FieldSchema ToGrpc()
     {
+        if (DataType == MilvusDataType.Text && MaxLength is null)
+        {
+            throw new ArgumentException(
+                $"Field '{Name}' is a {nameof(MilvusDataType.Text)} field with no {nameof(MaxLength)}. Milvus's own " +
+                "schema validation does not catch this at collection-creation time, but a live Milvus 2.6.4 container " +
+                "crashes its entire server process on a delayed WAL-recovery pass when it finds one -- see " +
+                $"{nameof(CreateText)}'s documentation for the full panic trace. Set {nameof(MaxLength)}, e.g. via " +
+                $"{nameof(CreateText)}, instead of the general {nameof(Create)} overload.");
+        }
+
         Grpc.FieldSchema grpcField = new()
         {
             Name = Name,

--- a/Milvus.Client/MilvusClient.Analyzer.cs
+++ b/Milvus.Client/MilvusClient.Analyzer.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+
+namespace Milvus.Client;
+
+public partial class MilvusClient
+{
+    /// <summary>
+    /// Runs a text analyzer over one or more input strings and returns the resulting tokens, without
+    /// requiring any data to be inserted. Useful for previewing how a given analyzer configuration (or an
+    /// existing field's configured analyzer) will tokenize text before committing to it in a schema.
+    /// Available since Milvus v2.5.
+    /// </summary>
+    /// <param name="texts">The input strings to analyze.</param>
+    /// <param name="analyzerParams">
+    /// The analyzer configuration to test, e.g. <c>new Dictionary&lt;string, object&gt; { ["type"] = "english" }</c>.
+    /// Mutually exclusive with <paramref name="collectionName" />/<paramref name="fieldName" />: to test a
+    /// field's own already-configured analyzer instead of an ad hoc one, pass those instead and leave this
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="collectionName">
+    /// Together with <paramref name="fieldName" />, runs that field's own configured analyzer instead of
+    /// <paramref name="analyzerParams" />. The collection must be loaded, and -- verified against Milvus
+    /// 2.6.4 -- the field must be the input field of a BM25 function; any other field, even one with
+    /// <see cref="FieldSchema.EnableAnalyzer" /> set, is rejected with "now only support run analyzer by
+    /// field if field was bm25 input field".
+    /// </param>
+    /// <param name="fieldName">See <paramref name="collectionName" />.</param>
+    /// <param name="withDetail">
+    /// Whether to include position and offset detail for each token. When <see langword="false" /> (the
+    /// default), <see cref="AnalyzerToken.StartOffset" />, <see cref="AnalyzerToken.EndOffset" /> and
+    /// <see cref="AnalyzerToken.Position" /> all come back as 0 rather than being omitted.
+    /// </param>
+    /// <param name="withHash">Whether to include each token's hash.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <returns>
+    /// One list of <see cref="AnalyzerToken" /> per input string, in the same order as
+    /// <paramref name="texts" />.
+    /// </returns>
+    public async Task<IReadOnlyList<IReadOnlyList<AnalyzerToken>>> RunAnalyzerAsync(
+        IReadOnlyList<string> texts,
+        IReadOnlyDictionary<string, object>? analyzerParams = null,
+        string? collectionName = null,
+        string? fieldName = null,
+        bool withDetail = false,
+        bool withHash = false,
+        CancellationToken cancellationToken = default)
+    {
+        Verify.NotNull(texts);
+
+        RunAnalyzerRequest request = new()
+        {
+            WithDetail = withDetail,
+            WithHash = withHash,
+        };
+
+        request.Placeholder.AddRange(texts.Select(ByteString.CopyFromUtf8));
+
+        if (analyzerParams is not null)
+        {
+            request.AnalyzerParams = JsonSerializer.Serialize(analyzerParams);
+        }
+
+        if (collectionName is not null)
+        {
+            request.CollectionName = collectionName;
+        }
+
+        if (fieldName is not null)
+        {
+            request.FieldName = fieldName;
+        }
+
+        RunAnalyzerResponse response = await InvokeAsync(
+                GrpcClient.RunAnalyzerAsync, request, static r => r.Status, cancellationToken)
+            .ConfigureAwait(false);
+
+        List<IReadOnlyList<AnalyzerToken>> results = new(response.Results.Count);
+        foreach (AnalyzerResult result in response.Results)
+        {
+            List<AnalyzerToken> tokens = new(result.Tokens.Count);
+            foreach (Grpc.AnalyzerToken token in result.Tokens)
+            {
+                tokens.Add(new AnalyzerToken(
+                    token.Token, token.StartOffset, token.EndOffset, token.Position, token.PositionLength,
+                    withHash ? token.Hash : null));
+            }
+
+            results.Add(tokens);
+        }
+
+        return results;
+    }
+}

--- a/Milvus.Client/MilvusClient.Analyzer.cs
+++ b/Milvus.Client/MilvusClient.Analyzer.cs
@@ -49,6 +49,22 @@ public partial class MilvusClient
     {
         Verify.NotNull(texts);
 
+        bool hasFieldRef = collectionName is not null || fieldName is not null;
+
+        if (analyzerParams is not null && hasFieldRef)
+        {
+            throw new ArgumentException(
+                $"{nameof(analyzerParams)} is mutually exclusive with {nameof(collectionName)}/{nameof(fieldName)} -- " +
+                "pass one or the other, not both.");
+        }
+
+        if (hasFieldRef && (collectionName is null || fieldName is null))
+        {
+            throw new ArgumentException(
+                $"{nameof(collectionName)} and {nameof(fieldName)} must be supplied together to run a field's " +
+                "own configured analyzer.");
+        }
+
         RunAnalyzerRequest request = new()
         {
             WithDetail = withDetail,

--- a/Milvus.Client/MilvusClient.Collection.cs
+++ b/Milvus.Client/MilvusClient.Collection.cs
@@ -146,6 +146,15 @@ public partial class MilvusClient
                 });
             }
 
+            if (field.EnableMatch)
+            {
+                grpcField.TypeParams.Add(new Grpc.KeyValuePair
+                {
+                    Key = Constants.EnableMatch,
+                    Value = "true"
+                });
+            }
+
             grpcCollectionSchema.Fields.Add(grpcField);
         }
 

--- a/Milvus.Client/MilvusCollection.Collection.cs
+++ b/Milvus.Client/MilvusCollection.Collection.cs
@@ -69,6 +69,10 @@ public partial class MilvusCollection
                     case Constants.AnalyzerParams:
                         milvusField.AnalyzerParams = JsonSerializer.Deserialize<Dictionary<string, object>>(parameter.Value);
                         break;
+
+                    case Constants.EnableMatch:
+                        milvusField.EnableMatch = parameter.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+                        break;
                 }
             }
 

--- a/Milvus.Client/MilvusCollection.Rows.cs
+++ b/Milvus.Client/MilvusCollection.Rows.cs
@@ -90,6 +90,61 @@ public partial class MilvusCollection
     }
 
     /// <summary>
+    /// Retrieves rows from a collection via scalar filtering, in the same row-dictionary shape accepted
+    /// by the row-based <see cref="InsertAsync(IReadOnlyList{IDictionary{string, object}}, string, CancellationToken)" />.
+    /// </summary>
+    /// <param name="expression">A boolean expression determining which rows are to be returned.</param>
+    /// <param name="parameters">Various additional optional parameters to configure the query.</param>
+    /// <param name="cancellationToken">
+    /// The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None" />.
+    /// </param>
+    /// <returns>
+    /// One dictionary per matched row, mapping each requested field name to its value. This is a
+    /// convenience over <see cref="QueryAsync(string, QueryParameters?, CancellationToken)" />, which
+    /// returns the same data column-oriented; it is not a distinct server operation.
+    /// </returns>
+    public async Task<IReadOnlyList<IReadOnlyDictionary<string, object?>>> QueryRowsAsync(
+        string expression,
+        QueryParameters? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<FieldData> columns = await QueryAsync(expression, parameters, cancellationToken)
+            .ConfigureAwait(false);
+
+        return PivotToRows(columns);
+    }
+
+    /// <summary>
+    /// Pivots column-oriented <see cref="FieldData" /> -- what the wire protocol actually returns --
+    /// into one dictionary per row. Used by <see cref="QueryRowsAsync" /> and by
+    /// <see cref="SearchResults.GetHits(int)" />.
+    /// </summary>
+    internal static List<Dictionary<string, object?>> PivotToRows(IReadOnlyList<FieldData> columns)
+    {
+        if (columns.Count == 0)
+        {
+            return new List<Dictionary<string, object?>>();
+        }
+
+        long rowCount = columns[0].RowCount;
+        List<Dictionary<string, object?>> rows = new((int)rowCount);
+        for (int i = 0; i < rowCount; i++)
+        {
+            rows.Add(new Dictionary<string, object?>(columns.Count, StringComparer.Ordinal));
+        }
+
+        foreach (FieldData column in columns)
+        {
+            for (int i = 0; i < rowCount; i++)
+            {
+                rows[i][column.FieldName!] = column.GetRowValue(i);
+            }
+        }
+
+        return rows;
+    }
+
+    /// <summary>
     /// Pivots row dictionaries into the column-oriented <see cref="FieldData" /> the wire protocol
     /// expects, using the collection schema to decide each column's type.
     /// </summary>

--- a/Milvus.Client/MilvusCollection.Rows.cs
+++ b/Milvus.Client/MilvusCollection.Rows.cs
@@ -119,15 +119,22 @@ public partial class MilvusCollection
     /// into one dictionary per row. Used by <see cref="QueryRowsAsync" /> and by
     /// <see cref="SearchResults.GetHits(int)" />.
     /// </summary>
-    internal static List<Dictionary<string, object?>> PivotToRows(IReadOnlyList<FieldData> columns)
+    /// <param name="columns">The columns to pivot.</param>
+    /// <param name="start">The first row index to include, e.g. one query's share of a multi-query search.</param>
+    /// <param name="count">
+    /// The number of rows to include starting at <paramref name="start" />; the rest of the column's
+    /// rows when <see langword="null" /> (the default).
+    /// </param>
+    internal static List<Dictionary<string, object?>> PivotToRows(
+        IReadOnlyList<FieldData> columns, int start = 0, int? count = null)
     {
         if (columns.Count == 0)
         {
             return new List<Dictionary<string, object?>>();
         }
 
-        long rowCount = columns[0].RowCount;
-        List<Dictionary<string, object?>> rows = new((int)rowCount);
+        int rowCount = count ?? (int)columns[0].RowCount - start;
+        List<Dictionary<string, object?>> rows = new(rowCount);
         for (int i = 0; i < rowCount; i++)
         {
             rows.Add(new Dictionary<string, object?>(columns.Count, StringComparer.Ordinal));
@@ -137,7 +144,7 @@ public partial class MilvusCollection
         {
             for (int i = 0; i < rowCount; i++)
             {
-                rows[i][column.FieldName!] = column.GetRowValue(i);
+                rows[i][column.FieldName!] = column.GetRowValue(start + i);
             }
         }
 

--- a/Milvus.Client/MilvusCollection.Rows.cs
+++ b/Milvus.Client/MilvusCollection.Rows.cs
@@ -233,6 +233,8 @@ public partial class MilvusCollection
 
             MilvusDataType.String or MilvusDataType.VarChar
                 => FieldData.CreateVarChar(field.Name, TextColumn(field.Name, values, ToText, field.Nullable)),
+            MilvusDataType.Text
+                => FieldData.CreateText(field.Name, TextColumn(field.Name, values, ToText, field.Nullable)),
             MilvusDataType.Geometry
                 => FieldData.CreateGeometry(field.Name, TextColumn(field.Name, values, ToText, field.Nullable)),
             MilvusDataType.Timestamptz

--- a/Milvus.Client/MilvusCollection.Rows.cs
+++ b/Milvus.Client/MilvusCollection.Rows.cs
@@ -90,8 +90,11 @@ public partial class MilvusCollection
     }
 
     /// <summary>
-    /// Retrieves rows from a collection via scalar filtering, in the same row-dictionary shape accepted
-    /// by the row-based <see cref="InsertAsync(IReadOnlyList{IDictionary{string, object}}, string, CancellationToken)" />.
+    /// Retrieves rows from a collection via scalar filtering, using the same field name/value shape as
+    /// the row-based <see cref="InsertAsync(IReadOnlyList{IDictionary{string, object}}, string, CancellationToken)" />
+    /// -- though each returned row is read-only (<see cref="IReadOnlyDictionary{TKey, TValue}" />), so
+    /// feeding it back into a row-based insert or upsert (which take a mutable <see cref="IDictionary{TKey, TValue}" />)
+    /// requires copying into a new <see cref="Dictionary{TKey, TValue}" /> first.
     /// </summary>
     /// <param name="expression">A boolean expression determining which rows are to be returned.</param>
     /// <param name="parameters">Various additional optional parameters to configure the query.</param>
@@ -133,7 +136,33 @@ public partial class MilvusCollection
             return new List<Dictionary<string, object?>>();
         }
 
-        int rowCount = count ?? (int)columns[0].RowCount - start;
+        long firstColumnRowCount = columns[0].RowCount;
+        foreach (FieldData column in columns)
+        {
+            if (column.RowCount != firstColumnRowCount)
+            {
+                throw new MilvusException(
+                    $"Column '{column.FieldName}' has {column.RowCount} rows, but column " +
+                    $"'{columns[0].FieldName}' has {firstColumnRowCount} -- the server returned " +
+                    "inconsistent column lengths, so these columns cannot be pivoted into rows.");
+            }
+        }
+
+        if (start < 0 || start > firstColumnRowCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(start), start, $"Must be in [0, {firstColumnRowCount}] -- these columns have {firstColumnRowCount} rows.");
+        }
+
+        int rowCount = count ?? (int)firstColumnRowCount - start;
+
+        if (rowCount < 0 || start + rowCount > firstColumnRowCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(count), count,
+                $"start ({start}) + count ({rowCount}) must not exceed the columns' row count ({firstColumnRowCount}).");
+        }
+
         List<Dictionary<string, object?>> rows = new(rowCount);
         for (int i = 0; i < rowCount; i++)
         {
@@ -369,8 +398,8 @@ public partial class MilvusCollection
     }
 
     /// <summary>
-    /// Projects a column whose values travel as text. The varchar, geometry and timestamptz wire paths
-    /// all carry nulls themselves, so this only has to decide whether a null is allowed.
+    /// Projects a column whose values travel as text. The varchar, text, geometry and timestamptz wire
+    /// paths all carry nulls themselves, so this only has to decide whether a null is allowed.
     /// </summary>
     private static List<string?> TextColumn(
         string fieldName, object?[] values, RowConverter<string> convert, bool nullable)

--- a/Milvus.Client/MilvusDataType.cs
+++ b/Milvus.Client/MilvusDataType.cs
@@ -74,6 +74,14 @@ public enum MilvusDataType
     Geometry = 24,
 
     /// <summary>
+    /// Free-form text intended for longer content than <see cref="VarChar" />, sharing the same wire
+    /// representation. Available since Milvus v2.6. Cannot be a primary key, a partition key, or an
+    /// <see cref="Array" /> element type, and does not support a default value. See
+    /// <see cref="FieldSchema.CreateText" />.
+    /// </summary>
+    Text = 25,
+
+    /// <summary>
     /// Timezone-aware timestamp, carried as an ISO 8601 string. Available since Milvus v2.6.
     /// </summary>
     Timestamptz = 26,

--- a/Milvus.Client/SearchHit.cs
+++ b/Milvus.Client/SearchHit.cs
@@ -1,0 +1,31 @@
+namespace Milvus.Client;
+
+/// <summary>
+/// One matched entity from a <see cref="SearchResults" />, combining its ID, similarity score and
+/// requested output fields into a single directly-usable row. See <see cref="SearchResults.GetHits(int)" />.
+/// </summary>
+public sealed class SearchHit
+{
+    internal SearchHit(object id, float score, IReadOnlyDictionary<string, object?> fields)
+    {
+        Id = id;
+        Score = score;
+        Fields = fields;
+    }
+
+    /// <summary>
+    /// The primary key of the matched entity: a <see cref="long" /> or a <see cref="string" />,
+    /// depending on the collection's primary key type.
+    /// </summary>
+    public object Id { get; }
+
+    /// <summary>
+    /// The similarity score for this hit.
+    /// </summary>
+    public float Score { get; }
+
+    /// <summary>
+    /// The requested output fields for this hit, as specified by <see cref="SearchParameters.OutputFields" />.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> Fields { get; }
+}

--- a/Milvus.Client/SearchResults.cs
+++ b/Milvus.Client/SearchResults.cs
@@ -35,4 +35,45 @@ public sealed class SearchResults
 
     public required IReadOnlyList<long> Limits { get; init; }
 #pragma warning restore CS1591
+
+    /// <summary>
+    /// Combines <see cref="Ids" />, <see cref="Scores" /> and <see cref="FieldsData" /> into one
+    /// <see cref="SearchHit" /> per matched entity for a single query vector -- a directly-usable row,
+    /// rather than three parallel column-oriented arrays the caller has to zip together by hand.
+    /// </summary>
+    /// <param name="queryIndex">
+    /// Which query vector's hits to return. A search can run against several query vectors at once
+    /// (<see cref="NumQueries" />), and every array on this type is a flat concatenation of each
+    /// query's hits in order; this slices out just one query's share, using <see cref="Limits" />.
+    /// Defaults to 0, the common case of searching with a single query vector.
+    /// </param>
+    public IReadOnlyList<SearchHit> GetHits(int queryIndex = 0)
+    {
+        if (queryIndex < 0 || queryIndex >= Limits.Count)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(queryIndex), queryIndex,
+                $"Must be in [0, {Limits.Count}) -- this result has {NumQueries} quer" +
+                (NumQueries == 1 ? "y" : "ies") + ".");
+        }
+
+        int start = 0;
+        for (int i = 0; i < queryIndex; i++)
+        {
+            start += (int)Limits[i];
+        }
+
+        int count = (int)Limits[queryIndex];
+        List<Dictionary<string, object?>> rows = MilvusCollection.PivotToRows(FieldsData);
+
+        List<SearchHit> hits = new(count);
+        for (int i = start; i < start + count; i++)
+        {
+            object id = Ids.LongIds is not null ? Ids.LongIds[i] : Ids.StringIds![i];
+            IReadOnlyDictionary<string, object?> fields = i < rows.Count ? rows[i] : new Dictionary<string, object?>();
+            hits.Add(new SearchHit(id, Scores[i], fields));
+        }
+
+        return hits;
+    }
 }

--- a/Milvus.Client/SearchResults.cs
+++ b/Milvus.Client/SearchResults.cs
@@ -58,12 +58,34 @@ public sealed class SearchResults
         }
 
         int start = 0;
-        for (int i = 0; i < queryIndex; i++)
+        checked
         {
-            start += (int)Limits[i];
+            try
+            {
+                for (int i = 0; i < queryIndex; i++)
+                {
+                    start += (int)Limits[i];
+                }
+            }
+            catch (OverflowException exception)
+            {
+                throw new MilvusException(
+                    $"This result's {nameof(Limits)} overflow a 32-bit row offset before reaching query " +
+                    $"{queryIndex}; the server-reported hit counts are too large for {nameof(GetHits)} to slice.",
+                    exception);
+            }
         }
 
-        int count = (int)Limits[queryIndex];
+        int count = checked((int)Limits[queryIndex]);
+
+        int idCount = Ids.LongIds?.Count ?? Ids.StringIds?.Count ?? 0;
+        if (start + count > idCount || start + count > Scores.Count)
+        {
+            throw new MilvusException(
+                $"Query {queryIndex}'s slice [{start}, {start + count}) does not fit within the " +
+                $"{idCount} id(s) and {Scores.Count} score(s) this result actually carries -- the server " +
+                $"reported inconsistent {nameof(Limits)} for this search.");
+        }
 
         // Only this query's slice of FieldsData needs pivoting, not the whole (potentially
         // multi-query) result -- PivotToRows(start, count) avoids re-pivoting every other query's

--- a/Milvus.Client/SearchResults.cs
+++ b/Milvus.Client/SearchResults.cs
@@ -64,14 +64,18 @@ public sealed class SearchResults
         }
 
         int count = (int)Limits[queryIndex];
-        List<Dictionary<string, object?>> rows = MilvusCollection.PivotToRows(FieldsData);
+
+        // Only this query's slice of FieldsData needs pivoting, not the whole (potentially
+        // multi-query) result -- PivotToRows(start, count) avoids re-pivoting every other query's
+        // rows on every call.
+        List<Dictionary<string, object?>> rows = MilvusCollection.PivotToRows(FieldsData, start, count);
 
         List<SearchHit> hits = new(count);
-        for (int i = start; i < start + count; i++)
+        for (int i = 0; i < count; i++)
         {
-            object id = Ids.LongIds is not null ? Ids.LongIds[i] : Ids.StringIds![i];
+            object id = Ids.LongIds is not null ? Ids.LongIds[start + i] : Ids.StringIds![start + i];
             IReadOnlyDictionary<string, object?> fields = i < rows.Count ? rows[i] : new Dictionary<string, object?>();
-            hits.Add(new SearchHit(id, Scores[i], fields));
+            hits.Add(new SearchHit(id, Scores[start + i], fields));
         }
 
         return hits;


### PR DESCRIPTION
## Summary
- **`Text` (25) data type** — `MilvusDataType.Text`, `FieldSchema.CreateText`, shares VarChar's `string_data` wire slot (same pattern as Timestamptz)
- **`TEXT_MATCH` support** — `FieldSchema.EnableMatch` on both `CreateVarchar` and `CreateText`, builds the inverted index `TEXT_MATCH` filter expressions need (requires `EnableAnalyzer` too)
- **`MilvusClient.RunAnalyzerAsync`** — previews analyzer tokenization, either ad hoc (`analyzerParams`) or against a real field's own configured analyzer (`collectionName`/`fieldName`)
- **Row-based query/search results** — `MilvusCollection.QueryRowsAsync` and `SearchResults.GetHits()`, mirroring #138's write-side row pivot on the read side. Closes #100 and the gap the #96 tracker flagged ("QueryResults/SearchResults to return row-based results")

## Verified server behavior (not assumed from docs)
- **⚠️ Root-caused a real Milvus 2.6.4 server bug, via the server's own logs, not just symptoms.** A collection containing a `Text` field with no `max_length` makes the streaming-node flusher unrecoverably **panic — crashing the entire server process** — the next time it recovers/rescans WAL channels:
  ```
  panic: new a empty data sync service should never be failed, the max_length was not specified, field type is Text
    .../flushcommon/pipeline.NewEmptyStreamingNodeDataSyncService(...)
    .../flusherimpl.(*flusherComponents).WhenCreateCollection(...)
    created by .../flusherimpl.RecoverWALFlusher
  ```
  Because that recovery pass can run well after the collection was created (even after it's dropped again), the crash surfaces later and initially looked like a concurrency issue — it isn't; a single, later, unrelated-looking operation just happens to be running when recovery finally fires. Filed upstream: milvus-io/milvus#53291.

  `FieldSchema.CreateText` requires `maxLength` as a mandatory parameter so nothing going through that factory can trigger this — but per review feedback, the general `FieldSchema.Create(name, MilvusDataType.Text, ...)` overload (and any hand-built `FieldSchema`) could still produce the bad shape, since it has no `maxLength` parameter to require one through. `FieldSchema.ToGrpc()` itself now rejects a `Text` field with no `MaxLength` with an `ArgumentException`, regardless of which factory built it, so the crash-triggering shape can no longer reach the server via any path. The regression test that deliberately builds the bad shape (`TextMaxLengthCrashRegressionTests`) runs against its own dedicated, disposable `IsolatedMilvusFixture` container instead of the assembly-wide shared one everything else depends on, and now asserts the client-side `ArgumentException` `CreateCollectionAsync` raises before ever reaching the server. (`IsolatedMilvusFixture` also parses the target version from `MILVUS_IMAGE` up front and skips starting a container at all below 2.6, so this costs nothing on the three older CI images.)
- No filter expression works against a `Text` field yet on 2.6.4, not even `TEXT_MATCH` ("filter on text field (...) is not supported yet") — filtering by content currently requires `VarChar` instead. The type is still fully usable for storage/read.
- `TEXT_MATCH` on `VarChar`: 2.5.20 doesn't actually enforce `EnableMatch` (works with just `EnableAnalyzer`); the strict "does not enable match" rejection only starts in 2.6.
- `RunAnalyzerAsync`'s field-based mode only works when the field is a **BM25 function's input field** — verified against 2.6.4; any other field, even with `EnableAnalyzer` set, is rejected. Undocumented anywhere I could find except the server's own error message.
- `withDetail`/`withHash` on `RunAnalyzerAsync` gate whether `AnalyzerToken.StartOffset`/`EndOffset`/`Position`/`Hash` are populated (they come back as 0/null otherwise, not omitted) — verified with live before/after comparisons.

## Test plan
34 tests across `TextTests`, `TextMatchTests`, `RunAnalyzerTests`, `RowResultsTests`, and the dedicated `TextMaxLengthCrashRegressionTests`, all passing individually and in combination. Full local suite (286 tests) run against all 4 CI images (2.3.22/2.4.23/2.5.20/2.6.4) with `MILVUS_IMAGE` — 285 passed, 1 pre-existing unrelated skip, 0 failed on every one, after the `ToGrpc()` guard above. `DisableParallelization` markers on `TextTests`/`TextMatchTests`/`RunAnalyzerTests`/`RowResultsTests` are left in place as ordinary defense-in-depth (same pattern already used by `DataTests`/`ResourceGroupTests`), not because those classes are known to trigger anything themselves.
